### PR TITLE
Correction of skipAssignment command that had wrong behaviour

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -652,9 +652,9 @@ SindarinDebuggerTest >> testSkipWith [
 	a := 1.
 	scdbg := SindarinDebugger
 		debug: [ a := 2.
-			p := Point x: 2 y: 3 ].
+			p := Point x: 2 y: 3  ].
 	scdbg skipWith: 3.
-	self assert: a equals: 1.
+	self assert: a equals: 3.
 	scdbg skipWith: 5.
 	scdbg step.
 	self assert: p equals: 5

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -494,8 +494,21 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skip [
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
-
+	self node isAssignment
+		ifTrue: [ ^ self skipAssignmentNodeCompletely ].
 	self skipWith: nil
+]
+
+{ #category : #'stepping -  skip' }
+SindarinDebugger >> skipAssignmentNodeCompletely [
+
+	self context pop.
+	"Pop the value to be assigned"
+	"Increase the pc to go over the assignment"
+	self context pc: (self context pc) + (self currentBytecode detect: [:each | each offset = self context pc ]) bytes size.
+	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
+	self debugSession stepToFirstInterestingBytecodeIn:
+		self debugSession interruptedProcess
 ]
 
 { #category : #'stepping -  skip' }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -504,8 +504,7 @@ SindarinDebugger >> skipAssignmentNodeWith: replacementValue [
 	"Pop the value to be assigned"
 	"Push the replacement value on the context's value stack, to simulate that the assignment happened and had value nil"
 	self context push: replacementValue.
-	"Increase the pc to go over the assignment"
-	self context pc: self context pc + 2.
+	self step.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
 	self debugSession
 		stepToFirstInterestingBytecodeIn: self debugSession interruptedProcess


### PR DESCRIPTION
Fixes #19
In `SindarinDebugger`, when you wanted to skip an assignment with the `skip` method; it was assigning `nil` to the variable that was supposed to be assigned, while you'd expect it to completely skip the assignment so that the assigned variable keep the same value as before the assignment.
Furthermore, to go over the assignment, the `skipAssignmentNodeWith:` was skipping an arbitrary number of bytes. As a result, sometimes, too many pc were skipped and some arguments were missing on the stack. In other cases, the replacement value that should have been assigned to the variable wasn't actually assigned.

To fix this, now, I've made a version `skipAssignmentNodeCompletely` that completely goes over the assignment by skipping the exact number of bytes there are in the bytecode that does the assignment. This version is used by default in the `skip` method.
I've also fixed the `skipAssignmentNodeWith:` so that the assignment is really made but with a replacement value pushed on the stack instead of the value that should have been assigned.
