### PR TITLE
Correction of stepToReturn command to be able to step to non-local returns.

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -3,8 +3,7 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'breakpointsBeforeTest',
-		'testObjectPoint',
-		'instanceBlock'
+		'testObjectPoint'
 	],
 	#category : #'Sindarin-Tests-Base'
 }
@@ -231,33 +230,6 @@ SindarinDebuggerTest >> helperMethodReturnWithHalt [
 	^ a + 1
 ]
 
-{ #category : #'as yet unclassified' }
-SindarinDebuggerTest >> helperMethodWithInst [
-	instanceBlock value.
-	^ 43
-]
-
-{ #category : #'as yet unclassified' }
-SindarinDebuggerTest >> helperMethodWithInstDefinedInContext [
-	instanceBlock := [ 1 + 2. ^ 42 ].
-	instanceBlock value.
-	^ 43
-]
-
-{ #category : #'as yet unclassified' }
-SindarinDebuggerTest >> helperMethodWithTemp [
-	| tempBlock a |
-	tempBlock := [ #(1 2 3) do: [ :number |  a := 1. ^ 42 ] ].
-	tempBlock value.
-	^ 43
-]
-
-{ #category : #accessing }
-SindarinDebuggerTest >> instanceBlock: aBlock [
-
-	instanceBlock := aBlock
-]
-
 { #category : #running }
 SindarinDebuggerTest >> runCaseManaged [
 	^ self runCase
@@ -271,7 +243,6 @@ SindarinDebuggerTest >> setUp [
 	breakpointsBeforeTest := VirtualBreakpoint all.
 	VirtualBreakpoint all removeAll.
 	testObjectPoint := Point x: 1 y: 2.
-	instanceBlock := [ 1 + 2. ^ 42 ].
 ]
 
 { #category : #running }

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'breakpointsBeforeTest',
-		'testObjectPoint'
+		'testObjectPoint',
+		'instanceBlock'
 	],
 	#category : #'Sindarin-Tests-Base'
 }
@@ -230,6 +231,33 @@ SindarinDebuggerTest >> helperMethodReturnWithHalt [
 	^ a + 1
 ]
 
+{ #category : #'as yet unclassified' }
+SindarinDebuggerTest >> helperMethodWithInst [
+	instanceBlock value.
+	^ 43
+]
+
+{ #category : #'as yet unclassified' }
+SindarinDebuggerTest >> helperMethodWithInstDefinedInContext [
+	instanceBlock := [ 1 + 2. ^ 42 ].
+	instanceBlock value.
+	^ 43
+]
+
+{ #category : #'as yet unclassified' }
+SindarinDebuggerTest >> helperMethodWithTemp [
+	| tempBlock a |
+	tempBlock := [ #(1 2 3) do: [ :number |  a := 1. ^ 42 ] ].
+	tempBlock value.
+	^ 43
+]
+
+{ #category : #accessing }
+SindarinDebuggerTest >> instanceBlock: aBlock [
+
+	instanceBlock := aBlock
+]
+
 { #category : #running }
 SindarinDebuggerTest >> runCaseManaged [
 	^ self runCase
@@ -243,6 +271,7 @@ SindarinDebuggerTest >> setUp [
 	breakpointsBeforeTest := VirtualBreakpoint all.
 	VirtualBreakpoint all removeAll.
 	testObjectPoint := Point x: 1 y: 2.
+	instanceBlock := [ 1 + 2. ^ 42 ].
 ]
 
 { #category : #running }

--- a/Sindarin/RBBlockDefinitionSearchingVisitor.class.st
+++ b/Sindarin/RBBlockDefinitionSearchingVisitor.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #RBBlockDefinitionSearchingVisitor,
+	#superclass : #RBProgramNodeVisitor,
+	#instVars : [
+		'blockToSearch',
+		'isBlockFound'
+	],
+	#category : #Sindarin
+}
+
+{ #category : #'instance creation' }
+RBBlockDefinitionSearchingVisitor class >> newToSearch: aBlockNode [
+
+	^ self new
+		  blockToSearch: aBlockNode;
+		  yourself
+]
+
+{ #category : #accessing }
+RBBlockDefinitionSearchingVisitor >> blockToSearch: aBlockNode [
+
+	blockToSearch := aBlockNode.
+	isBlockFound := false
+]
+
+{ #category : #initialization }
+RBBlockDefinitionSearchingVisitor >> initialize [
+
+	isBlockFound := false
+]
+
+{ #category : #accessing }
+RBBlockDefinitionSearchingVisitor >> isBlockFound [
+
+	^ isBlockFound
+]
+
+{ #category : #visiting }
+RBBlockDefinitionSearchingVisitor >> visitNode: aNode [
+
+	super visitNode: aNode.
+	aNode = blockToSearch ifTrue: [ isBlockFound := true ].
+	^ isBlockFound 
+]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -665,9 +665,13 @@ SindarinDebugger >> stepToMethodEntry [
 { #category : #'stepping - steps' }
 SindarinDebugger >> stepToReturn [
 
+	| oldContext |
+	oldContext := self context.
+
 	[ 
-	self context instructionStream willReturn or: [ self hasSignalledUnhandledException ] ] 
-		whileFalse: [ self debugSession stepOver ]
+	oldContext instructionStream willReturn or: [ 
+		self hasSignalledUnhandledException ] ] whileFalse: [ 
+		self debugSession stepThrough: oldContext ]
 ]
 
 { #category : #'stepping - steps' }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -669,7 +669,7 @@ SindarinDebugger >> stepToReturn [
 	oldContext := self context.
 
 	[ 
-	oldContext instructionStream willReturn or: [ 
+	(self context outerMostContext = oldContext and: [ self context instructionStream willReturn]) or: [ 
 		self hasSignalledUnhandledException ] ] whileFalse: [ 
 		self debugSession stepThrough: oldContext ]
 ]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -229,7 +229,7 @@ SindarinDebugger >> debugSession [
 { #category : #private }
 SindarinDebugger >> hasSignalledUnhandledException [
 	"Returns true if the debugged execution has signalled an exception that has not been handled by any on:do: (i.e. the #defaultAction of the exception is about to be executed. This default action typically leads to opening a debugger on the process that signalled the exception)"
-	^ (self selector = #defaultAction ) and: [ self receiver isKindOf: Exception ]
+	^ (#(#defaultAction #signal) includes: self selector ) and: [ self receiver isKindOf: Exception ]
 ]
 
 { #category : #initialization }
@@ -385,6 +385,18 @@ SindarinDebugger >> openInGraphicalDebugger [
 			'Should be an extension of DebuggerSelector and handled by its sole instance'
 ]
 
+{ #category : #'as yet unclassified' }
+SindarinDebugger >> outerMostContextOf: aContext [
+
+	| currentContext oldContext |
+	currentContext := aContext.
+	oldContext := nil.
+	[currentContext ~= oldContext] whileTrue: [ 
+		oldContext := currentContext.
+		currentContext := currentContext outerMostContext ].
+	^ currentContext
+]
+
 { #category : #accessing }
 SindarinDebugger >> pc [
 	^ self context pc
@@ -457,6 +469,28 @@ SindarinDebugger >> setBreakpointOn: target [
 	(target isKindOf: CompiledMethod)
 		ifTrue: [ astTarget := target ast ].
 	^ VirtualBreakpoint newOnNode: astTarget setBy: self
+]
+
+{ #category : #asserting }
+SindarinDebugger >> shouldStepIntoInMethod: aRBMethodNode [
+
+	| messageNode childrenOfMessageNode |
+	messageNode := self node.
+	messageNode isMessage ifFalse: [ ^ false ].
+	childrenOfMessageNode := messageNode children.
+	childrenOfMessageNode := childrenOfMessageNode
+		                         select: [ :child | 
+			                         child isBlock or: [ 
+				                         child isVariable and: [ 
+					                         (child variableValueInContext:
+						                          self context) isBlock ] ] ]
+		                         thenCollect: [ :child | 
+			                         child isVariable ifTrue: [ 
+				                         (child variableValueInContext:
+					                          self context) startpcOrOuterCode ast ] ].
+	^ childrenOfMessageNode anySatisfy: [ :child | 
+		  (RBBlockDefinitionSearchingVisitor newToSearch: child) visitNode:
+			  aRBMethodNode ]
 ]
 
 { #category : #private }
@@ -665,13 +699,20 @@ SindarinDebugger >> stepToMethodEntry [
 { #category : #'stepping - steps' }
 SindarinDebugger >> stepToReturn [
 
-	| oldContext |
-	oldContext := self context.
+	| oldContext methodAST |
+	oldContext := self outerMostContextOf: self context.
+	methodAST := self context method ast.
 
 	[ 
-	(self context outerMostContext = oldContext and: [ self context instructionStream willReturn]) or: [ 
+	((self outerMostContextOf: self context) = oldContext and: [ 
+		 self context instructionStream willReturn ]) or: [ 
 		self hasSignalledUnhandledException ] ] whileFalse: [ 
-		self debugSession stepThrough: oldContext ]
+		(self shouldStepIntoInMethod: methodAST)
+			ifTrue: [ self debugSession stepInto ]
+			ifFalse: [ self debugSession stepOver ] ]
+	"[ 
+	self context instructionStream willReturn or: [ self hasSignalledUnhandledException ] ] 
+		whileFalse: [ self debugSession stepOver ]"
 ]
 
 { #category : #'stepping - steps' }


### PR DESCRIPTION
Fixes #21 
In `SindarinDebugger`, the `stepToReturn` command didn't step to returns in blocks, as its implementation was using `stepOver`.

I've tried an implementation that uses `stepThrough`, which indeed fixed the problem, but that is problematic as `stepThrough` actually steps beyond exception signals if these exceptions are resumable.

I've also tried an implementation that uses `stepInto`, which also fixed the problem, but that is problematic as `stepInto` stops on halts, which is not the expected behaviour.

Now, the implementation I've done matches all 3 goals:
While a return hasn't been reached in the lexical context or an exception hasn't been signaled, we `stepOver` (to step on exceptions but not halts) except if we are on a message node that has, as a receiver or as an argument, a block that is defined in the same lexical context in which we step to return. In the latter case, we `stepInto` to enter the block.

Furthermore, `SindarinDebugger >> hasSignalledUnhandledException` has been modifed as it actually has never worked before to stop on exception signals. Indeed, the `Sindarin>>testStepToReturnWithException` was stopping correctly "by chance" on theexception signal because the current context, which is the context of the exception, returned.

Now,  `SindarinDebugger >> hasSignalledUnhandledException` actually causes `stepToreturn` to stop on exception signals.