### PR TITLE
Fixing skip command so that it leaves the receiver on the stack instead of putting nil on the stack

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -601,6 +601,35 @@ SindarinDebuggerTest >> testSkip [
 	self assert: p equals: nil
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipAssignmentWithStoreIntoBytecodePushesReplacementValueButNotWithPopIntoBytecode [
+
+	| a b dbg aFormerValue bFormerValue |
+	dbg := SindarinDebugger debug: [ 
+		       b := 1.
+		       [ 
+		       a := 2.
+		       a := b := 3 + 4 ] value.
+		       ^ 42 ].
+	dbg step.
+	dbg step.
+	dbg stepThrough. "we enter the block"
+
+	dbg skip. "we skip the assignment a:= 2"
+	self assert: dbg topStack equals: 4.
+	self assert: a equals: nil.
+
+	bFormerValue := b.
+	dbg step. dbg skip. "we skip the assignment b := 3 + 4"
+	self assert: dbg topStack equals: bFormerValue.
+	self assert: b equals: bFormerValue.
+
+	aFormerValue := a.
+	dbg skip. "we skip the assignment a:= (b := 3 + 4)"
+	self assert: dbg topStack equals: aFormerValue.
+	self assert: a equals: aFormerValue
+]
+
 { #category : #'tests - skipping' }
 SindarinDebuggerTest >> testSkipThroughNode [
 	| dbg realExecPC realValueOfA targetExecNode realExecTopStack nodeAfterSkipThrough |

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -704,6 +704,47 @@ SindarinDebuggerTest >> testSkipUpToNode [
 ]
 
 { #category : #'tests - skipping' }
+SindarinDebuggerTest >> testSkipUpToNodeInEvaluatedBlock [
+
+	| dbg realExecPC realExecNode realExecTopStack oldValueOfA |
+	self skipOnPharoCITestingEnvironment.
+	dbg := SindarinDebugger debug: [ self helperMethodWithEvaluatedBlock ].
+	"after stepping, we stop at the beginning of the block"
+	dbg
+		step;
+		step;
+		stepOver;
+		stepOver;
+		stepThrough.
+	oldValueOfA := dbg temporaryNamed: #a.
+	"after stepping, we stop on  b: = 3 + 2 assignment node"
+	dbg
+		stepOver;
+		stepOver.
+	realExecPC := dbg pc.
+	realExecNode := dbg node.
+	realExecTopStack := dbg topStack.
+
+	dbg := SindarinDebugger debug: [ self helperMethodWithEvaluatedBlock ].
+
+	dbg
+		step;
+		step;
+		stepOver;
+		stepOver;
+		stepThrough;
+		skipUpToNode: realExecNode.
+	self assert: dbg pc equals: realExecPC.
+	self assert: dbg node identicalTo: realExecNode.
+	self assert: (dbg temporaryNamed: #a) equals: oldValueOfA.
+	self assert: dbg topStack equals: nil.
+
+	dbg stepOver.
+	"nil is on the stack so stepping over the assignment should put nil into b"
+	self assert: (dbg temporaryNamed: #b) equals: nil
+]
+
+{ #category : #'tests - skipping' }
 SindarinDebuggerTest >> testSkipWith [
 	| a p scdbg |
 	self skipOnPharoCITestingEnvironment.

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -598,7 +598,7 @@ SindarinDebuggerTest >> testSkip [
 	self assert: a equals: 1.
 	scdbg skip.
 	scdbg step.
-	self assert: p equals: nil
+	self assert: p equals: Point
 ]
 
 { #category : #tests }
@@ -628,6 +628,23 @@ SindarinDebuggerTest >> testSkipAssignmentWithStoreIntoBytecodePushesReplacement
 	dbg skip. "we skip the assignment a:= (b := 3 + 4)"
 	self assert: dbg topStack equals: aFormerValue.
 	self assert: a equals: aFormerValue
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
+
+	| a scdbg |
+	a := 1.
+	scdbg := SindarinDebugger
+		debug: [ a := a + 2 ].
+	self assert: a equals: 1.
+	
+	scdbg skip.
+	scdbg step.
+	
+	self assert: a equals: 1
+	
+
 ]
 
 { #category : #'tests - skipping' }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -536,10 +536,20 @@ SindarinDebugger >> skip [
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skipAssignmentNodeCompletely [
 
+	| currentBytecode |
+	currentBytecode := self currentBytecode detect: [ :each | 
+		                   each offset = self context pc ].
+
+	"Pop the value that will be assigned"
 	self context pop.
-	"Pop the value to be assigned"
+
+	"If the assignment is a store bytecode and not a pop bytecode, we push the current value of the variable that was going to be assigned."
+	(#( 243 244 245 252 ) includes: currentBytecode bytes first) ifTrue: [ 
+		self context push:
+			(self node variable variableValueInContext: self context) ].
+
 	"Increase the pc to go over the assignment"
-	self context pc: (self context pc) + (self currentBytecode detect: [:each | each offset = self context pc ]) bytes size.
+	self context pc: self context pc + currentBytecode bytes size.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
 	self debugSession stepToFirstInterestingBytecodeIn:
 		self debugSession interruptedProcess

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -569,16 +569,18 @@ SindarinDebugger >> skipAssignmentNodeWith: replacementValue [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skipMessageNodeWith: replacementValue [
-	self node arguments do: [ :arg | self context pop ].	"Pop the arguments of the message send from the context's value stack"
-	"Pop the receiver from the context's value stack"
+
+	self node arguments do: [ :arg | self context pop ]. "Pop the arguments of the message send from the context's value stack"
+	"""Pop the receiver from the context's value stack""
 	self context pop.
-	"Push the replacement value on the context's value stack, to simulate that the message send happened and returned nil"
-	self context push: replacementValue.
+	""Push the replacement value on the context's value stack, to simulate that the message send happened and returned nil""
+	
+	self context push: self node receiver."
 	"Increase the pc to go over the message send"
 	self context pc: self context pc + 1.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
-	self debugSession
-		stepToFirstInterestingBytecodeIn: self debugSession interruptedProcess
+	self debugSession stepToFirstInterestingBytecodeIn:
+		self debugSession interruptedProcess
 ]
 
 { #category : #'stepping -  skip' }


### PR DESCRIPTION
Fixes #31.

When you were skipping a message, the result of the message send was nil.

So, if you skipped the message `+` in ```3 + 2```, the result was nil. However, you'd expect that the message `+` is not sent to `3` and that the result of skipping the message is therefore the receiver of the message itself: 3.

I fixed the skip command so that the result of skipping a message send is the receiver of the message itself.

Done with @DanielCamSan