### PR TITLE
Fixing skip command so that it leaves the receiver on the stack instead of putting nil on the stack

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -569,7 +569,22 @@ SindarinDebuggerTest >> testSkip [
 	self assert: a equals: 1.
 	scdbg skip.
 	scdbg step.
-	self assert: p equals: nil
+	self assert: p equals: Point
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
+
+	| a scdbg |
+ 	a := 1.
+ 	scdbg := SindarinDebugger
+ 		debug: [ a := a + 2 ].
+ 	self assert: a equals: 1.
+
+ 	scdbg skip.
+ 	scdbg step.
+
+ 	self assert: a equals: 1
 ]
 
 { #category : #'tests - skipping' }
@@ -596,7 +611,7 @@ SindarinDebuggerTest >> testSkipThroughNode [
 	self assert: realValueOfA equals: 5.
 	self assert: (dbg temporaryNamed: #a) equals: 1.
 	self assert: realExecTopStack equals: 3.
-	self assert: dbg topStack equals: nil
+	self assert: dbg topStack equals: '3'
 ]
 
 { #category : #'tests - skipping' }

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -909,5 +909,5 @@ SindarinDebuggerTest >> testskipUpToNodeSkipTargetNode [
 	returnNode := (self class >> #helperMethod1) ast statements last.
 	dbg step; skipThroughNode: returnNode.
 	self assert: dbg node equals: returnNode.
-	self assert: dbg topStack equals: nil
+	self assert: dbg topStack equals: Point
 ]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -558,8 +558,21 @@ SindarinDebugger >> skipAssignmentNodeWith: replacementValue [
 ]
 
 { #category : #'stepping -  skip' }
+SindarinDebugger >> skipMessageNode [
+
+	self node arguments do: [ :arg | self context pop ]. "Pop the arguments of the message send from the context's value stack"
+
+	"Increase the pc to go over the message send"
+	self context pc: self context pc + 1.
+	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
+	self debugSession stepToFirstInterestingBytecodeIn:
+		self debugSession interruptedProcess
+]
+
+{ #category : #'stepping -  skip' }
 SindarinDebugger >> skipMessageNodeWith: replacementValue [
-	self node arguments do: [ :arg | self context pop ].	"Pop the arguments of the message send from the context's value stack"
+
+	self node arguments do: [ :arg | self context pop ]. "Pop the arguments of the message send from the context's value stack"
 	"Pop the receiver from the context's value stack"
 	self context pop.
 	"Push the replacement value on the context's value stack, to simulate that the message send happened and returned nil"
@@ -567,8 +580,8 @@ SindarinDebugger >> skipMessageNodeWith: replacementValue [
 	"Increase the pc to go over the message send"
 	self context pc: self context pc + 1.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
-	self debugSession
-		stepToFirstInterestingBytecodeIn: self debugSession interruptedProcess
+	self debugSession stepToFirstInterestingBytecodeIn:
+		self debugSession interruptedProcess
 ]
 
 { #category : #'stepping -  skip' }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -527,9 +527,11 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skip [
+
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
-	self node isAssignment
-		ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+
+	self node isAssignment ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+	self node isMessage ifTrue: [ ^ self skipMessageNode ].
 	self skipWith: nil
 ]
 


### PR DESCRIPTION
Fixes #31 

When you were skipping a message, the result of the message send was nil.

So, if you skipped the message `+` in ```3 + 2```, the result was nil. However, you'd expect that the message `+` is not sent to 3 and that the result of skipping the message would therefore be the receiver of the message itself: 3.

I fixed the skip command so that the result of skipping a message send is the receiver of the message itself.

Done with @DanielCamSan