### PR TITLE
Fixing skip so that it skips the right number of bytes to skip message send bytecodes

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -568,6 +568,35 @@ SindarinDebuggerTest >> testSkip [
 	self assert: p equals: Point
 ]
 
+{ #category : #'tests - skipping' }
+SindarinDebuggerTest >> testSkipAssignmentWithStoreIntoBytecodePushesReplacementValueButNotWithPopIntoBytecode [
+
+	| a b dbg aFormerValue bFormerValue |
+	dbg := SindarinDebugger debug: [ 
+		       b := 1.
+		       [ 
+		       a := 2.
+		       a := b := 3 + 4 ] value.
+		       ^ 42 ].
+	dbg step.
+	dbg step.
+	dbg stepThrough. "we enter the block"
+
+	dbg skip. "we skip the assignment a:= 2"
+	self assert: dbg topStack equals: 4.
+	self assert: a equals: nil.
+
+	bFormerValue := b.
+	dbg step. dbg skip. "we skip the assignment b := 3 + 4"
+	self assert: dbg topStack equals: bFormerValue.
+	self assert: b equals: bFormerValue.
+
+	aFormerValue := a.
+	dbg skip. "we skip the assignment a:= (b := 3 + 4)"
+	self assert: dbg topStack equals: aFormerValue.
+	self assert: a equals: aFormerValue
+]
+
 { #category : #tests }
 SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
 
@@ -600,34 +629,6 @@ SindarinDebuggerTest >> testSkipSkipsSuperSendBytecodesCorrectly [
 	scdbg stepOver.
 
 	self assert: a equals: oldValueOfA
-]
-
-SindarinDebuggerTest >> testSkipAssignmentWithStoreIntoBytecodePushesReplacementValueButNotWithPopIntoBytecode [
-
-	| a b dbg aFormerValue bFormerValue |
-	dbg := SindarinDebugger debug: [ 
-		       b := 1.
-		       [ 
-		       a := 2.
-		       a := b := 3 + 4 ] value.
-		       ^ 42 ].
-	dbg step.
-	dbg step.
-	dbg stepThrough. "we enter the block"
-
-	dbg skip. "we skip the assignment a:= 2"
-	self assert: dbg topStack equals: 4.
-	self assert: a equals: nil.
-
-	bFormerValue := b.
-	dbg step. dbg skip. "we skip the assignment b := 3 + 4"
-	self assert: dbg topStack equals: bFormerValue.
-	self assert: b equals: bFormerValue.
-
-	aFormerValue := a.
-	dbg skip. "we skip the assignment a:= (b := 3 + 4)"
-	self assert: dbg topStack equals: aFormerValue.
-	self assert: a equals: aFormerValue
 ]
 
 { #category : #'tests - skipping' }

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -928,5 +928,5 @@ SindarinDebuggerTest >> testskipUpToNodeSkipTargetNode [
 	returnNode := (self class >> #helperMethod1) ast statements last.
 	dbg step; skipThroughNode: returnNode.
 	self assert: dbg node equals: returnNode.
-	self assert: dbg topStack equals: nil
+	self assert: dbg topStack equals: Point
 ]

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -587,6 +587,25 @@ SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
  	self assert: a equals: 1
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipSkipsSuperSendBytecodesCorrectly [
+
+	| a scdbg oldValueOfA negatedContext |
+	a := ScaledDecimal newFromNumber: 3 scale: 2.
+	scdbg := SindarinDebugger debug: [ a := a negated ].
+	oldValueOfA := a.
+
+	scdbg
+		step;
+		stepOver;
+		skip.
+	negatedContext := scdbg context.
+	scdbg stepUntil: [ scdbg context == negatedContext ].
+	scdbg stepOver.
+
+	self assert: a equals: oldValueOfA
+]
+
 { #category : #'tests - skipping' }
 SindarinDebuggerTest >> testSkipThroughNode [
 	| dbg realExecPC realValueOfA targetExecNode realExecTopStack nodeAfterSkipThrough |

--- a/Sindarin/RBBlockDefinitionSearchingVisitor.class.st
+++ b/Sindarin/RBBlockDefinitionSearchingVisitor.class.st
@@ -8,6 +8,14 @@ Class {
 	#category : #Sindarin
 }
 
+{ #category : #'instance creation' }
+RBBlockDefinitionSearchingVisitor class >> newToSearch: aBlockNode [
+
+	^ self new
+		  blockToSearch: aBlockNode;
+		  yourself
+]
+
 { #category : #accessing }
 RBBlockDefinitionSearchingVisitor >> blockToSearch: aBlockNode [
 

--- a/Sindarin/RBBlockDefinitionSearchingVisitor.class.st
+++ b/Sindarin/RBBlockDefinitionSearchingVisitor.class.st
@@ -8,14 +8,6 @@ Class {
 	#category : #Sindarin
 }
 
-{ #category : #'instance creation' }
-RBBlockDefinitionSearchingVisitor class >> newToSearch: aBlockNode [
-
-	^ self new
-		  blockToSearch: aBlockNode;
-		  yourself
-]
-
 { #category : #accessing }
 RBBlockDefinitionSearchingVisitor >> blockToSearch: aBlockNode [
 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -563,7 +563,7 @@ SindarinDebugger >> skipMessageNode [
 	self node arguments do: [ :arg | self context pop ]. "Pop the arguments of the message send from the context's value stack"
 
 	"Increase the pc to go over the message send"
-	self context pc: self context pc + 1.
+	self context pc: self context pc + self nextBytecode bytes size.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
 	self debugSession stepToFirstInterestingBytecodeIn:
 		self debugSession interruptedProcess
@@ -578,7 +578,7 @@ SindarinDebugger >> skipMessageNodeWith: replacementValue [
 	"Push the replacement value on the context's value stack, to simulate that the message send happened and returned nil"
 	self context push: replacementValue.
 	"Increase the pc to go over the message send"
-	self context pc: self context pc + 1.
+	self context pc: self context pc + self nextBytecode bytes size.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
 	self debugSession stepToFirstInterestingBytecodeIn:
 		self debugSession interruptedProcess

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -534,9 +534,11 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skip [
+
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
-	self node isAssignment
-		ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+
+	self node isAssignment ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+	self node isMessage ifTrue: [ ^ self skipMessageNode ].
 	self skipWith: nil
 ]
 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -363,6 +363,13 @@ SindarinDebugger >> method [
 	^ self context method
 ]
 
+{ #category : #'accessing - bytes' }
+SindarinDebugger >> nextBytecode [
+
+	^ self currentBytecode detect: [ :each | 
+		  each offset = self context pc ]
+]
+
 { #category : #astAndAstMapping }
 SindarinDebugger >> node [
 	"Returns the AST node about to be executed by the top context of the execution"


### PR DESCRIPTION
Fixes #34.

When a message send was skipped, it used increment the pc of one byte.

However, some message send bytecodes are made up of 2 bytes, so skipping 1 byte is arbitrar.

So, I fixed it so that it skips the exact number of bytes contained in the bytecode.

#33 needs to be merged first.

