### PR TITLE
39 skip doesnt skip method nodes

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -230,6 +230,15 @@ SindarinDebuggerTest >> helperMethodReturnWithHalt [
 	^ a + 1
 ]
 
+{ #category : #helpers }
+SindarinDebuggerTest >> helperMethodWithBlockWithNoReturn [
+
+	| block a |
+	block := [ a := 1 ].
+	block value.
+	^ 43
+]
+
 { #category : #running }
 SindarinDebuggerTest >> runCaseManaged [
 	^ self runCase

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -572,6 +572,32 @@ SindarinDebuggerTest >> testSkip [
 	self assert: p equals: nil
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipStepsMethodNodes [
+
+	| scdbg realExecNode realExecPc realTopStack |
+	scdbg := SindarinDebugger debug: [ 
+		         self helperMethodWithBlockWithNoReturn ].
+
+	scdbg step.
+	scdbg stepOver.
+
+	realExecNode := scdbg node.
+	realExecPc := scdbg pc.
+	realTopStack := scdbg topStack.
+
+	scdbg := SindarinDebugger debug: [ 
+		         self helperMethodWithBlockWithNoReturn ].
+
+	scdbg
+		step;
+		skip.
+
+	self assert: scdbg node identicalTo: realExecNode.
+	self assert: scdbg pc identicalTo: realExecPc.
+	self assert: scdbg topStack equals: realTopStack
+]
+
 { #category : #'tests - skipping' }
 SindarinDebuggerTest >> testSkipThroughNode [
 	| dbg realExecPC realValueOfA targetExecNode realExecTopStack nodeAfterSkipThrough |

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -527,9 +527,11 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skip [
+
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
-	self node isAssignment
-		ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+
+	self node isAssignment ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+	self node isMethod ifTrue: [ ^ self step ].
 	self skipWith: nil
 ]
 


### PR DESCRIPTION
Fixes #39 

When the sindarin debugger is stopped on a method node, the skip command doesn't do anything (it doesn't skip it nor it steps it), which causes the skipUpTo command to enter an infinite loop.

I fixed it so that the skip command steps when the current node is a method node, because the bytecodes on which we are stopped are bytecodes that are invisible to users and thus, that they don't want to skip