### PR TITLE
Synchronising with changes made in Pharo repo a year and a half ago

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -385,15 +385,12 @@ SindarinDebuggerTest >> testIsAboutToInstantiateClass [
 
 { #category : #tests }
 SindarinDebuggerTest >> testIsExecutionFinished [
-	"Test shows that the debugger is actually not correctly working and therefore it is disabled.
-	The fix requires the changes in #isExecutionFinished and on the Pharo side (PR#8567)
-	Once integrated there will be another PR here. 
-	Projects are managed in different repos and therfore such complex integration"
+
 	| scdbg |
 	self skipOnPharoCITestingEnvironment.
 	scdbg := SindarinDebugger debug: [ self helperMethod16 ].
 	self deny: scdbg isExecutionFinished.
-	
+
 	[ scdbg isExecutionFinished ] whileFalse: [ scdbg stepOver ].
 
 	self assert: scdbg currentProcess isTerminated

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -382,7 +382,7 @@ SindarinDebugger >> openInGraphicalDebugger [
 			'Should be an extension of DebuggerSelector and handled by its sole instance'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'accessing - context' }
 SindarinDebugger >> outerMostContextOf: aContext [
 
 	| currentContext oldContext |

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -269,7 +269,7 @@ SindarinDebugger >> isAboutToSignalException [
 SindarinDebugger >> isExecutionFinished [
 	"Returns whether the debugged execution is finished"
 
-	^ process isTerminating
+	^ process isTerminated
 ]
 
 { #category : #stackAccessHelpers }


### PR DESCRIPTION
Fixes #25.

Some changes were made in the Pharo repo to use the correct API of the class `Process`: https://github.com/pharo-project/pharo/pull/8567/files#diff-ba7fcd4a659f90f879b1491dc051a7f1566317e9eecde109cdb67e56618177db

These changes have been integrated into this repo by #43 but some changes in the method have been forgotten:

```Smalltalk
SindarinDebugger>>#isExecutionFinished
^ process isTerminating
```

should actually be 

```Smalltalk
SindarinDebugger>>#isExecutionFinished
^ process isTerminated
```

so that `testIsExecutionFinished` becomes green
