### PR TITLE
Fixing skip so that it skips block creations

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -568,6 +568,46 @@ SindarinDebuggerTest >> testSkip [
 	self assert: p equals: nil
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipBlockNode [
+
+	| scdbg targetContext |
+	scdbg := SindarinDebugger debug: [ self helperMethodNonLocalReturn ].
+
+	scdbg
+		step;
+		step.
+
+	self assert: scdbg topStack isBlock.
+
+	scdbg stepUntil: [ 
+		scdbg node isMessage and: [ scdbg messageSelector = #value ] ].
+
+	targetContext := scdbg context sender.
+	scdbg stepOver.
+
+	self assert: scdbg context identicalTo: targetContext.
+	self assert: scdbg topStack equals: 42.
+
+	scdbg := SindarinDebugger debug: [ self helperMethodNonLocalReturn ].
+
+	scdbg
+		step;
+		skip.
+
+	self assert: scdbg topStack isNil.
+
+	scdbg stepUntil: [ 
+		scdbg node isMessage and: [ scdbg messageSelector = #value ] ].
+
+	targetContext := scdbg context.
+
+	scdbg stepOver.
+
+	self assert: scdbg context identicalTo: targetContext.
+	self assert: scdbg topStack equals: 43
+]
+
 { #category : #'tests - skipping' }
 SindarinDebuggerTest >> testSkipThroughNode [
 	| dbg realExecPC realValueOfA targetExecNode realExecTopStack nodeAfterSkipThrough |

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -593,6 +593,7 @@ SindarinDebugger >> skipBlockNode [
 	self context push: nil
 ]
 
+{ #category : #'stepping - skip' }
 SindarinDebugger >> skipMessageNode [
 
 	self node arguments do: [ :arg | self context pop ]. "Pop the arguments of the message send from the context's value stack"

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -524,9 +524,12 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skip [
+
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
-	self node isAssignment
-		ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+
+	self node isAssignment ifTrue: [ ^ self skipAssignmentNodeCompletely ].
+	self node isBlock ifTrue: [ self skipBlockNode ].
+
 	self skipWith: nil
 ]
 
@@ -552,6 +555,17 @@ SindarinDebugger >> skipAssignmentNodeWith: replacementValue [
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
 	self debugSession
 		stepToFirstInterestingBytecodeIn: self debugSession interruptedProcess
+]
+
+{ #category : #'stepping -  skip' }
+SindarinDebugger >> skipBlockNode [
+
+	| nextBytecode |
+	nextBytecode := self currentBytecode detect: [ :bytecode | bytecode offset = self pc ].
+	
+	self context pc: self pc + nextBytecode bytes size.
+	
+	self context push: nil
 ]
 
 { #category : #'stepping -  skip' }


### PR DESCRIPTION
Fixes #38 

When `skip` met a block node for a block creation, it didn't do anything and caused skipUpTo to enter an infinite loop and freeze the image.

I fixed it by skipping the block creation byte code and pushing nil on the stack instead of the block.