### PR TITLE
28 skip through and skip up to sometimes freeze the image when skipping in a block

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -239,6 +239,19 @@ SindarinDebuggerTest >> helperMethodWithBlockWithNoReturn [
 	^ 43
 ]
 
+{ #category : #helpers }
+SindarinDebuggerTest >> helperMethodWithSeveralInstructionsInBlock [
+
+	| a b block |
+	a := 3.
+	block := [ 
+	         a := 1.
+	         b := 2.
+	         1 + 2 ].
+	b := block value.
+	^ 42
+]
+
 { #category : #running }
 SindarinDebuggerTest >> runCaseManaged [
 	^ self runCase
@@ -304,6 +317,62 @@ SindarinDebuggerTest >> testAssignmentVariableName [
 	scdbg := SindarinDebugger debug: [ self helperMethod3 ].
 	scdbg step.
 	self assert: scdbg assignmentVariableName equals: #a
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsAfterInAnyContext [
+
+	| sdbg aimedNodeInContext aimedNodeOutsideContext |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithSeveralInstructionsInBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver;
+		stepOver;
+		stepThrough;
+		stepOver.
+
+	aimedNodeInContext := sdbg methodNode body statements last.
+
+	self assert: sdbg pc
+		< (sdbg methodNode lastPcForNode: aimedNodeInContext).
+	self assert: (sdbg canStillExecute: aimedNodeInContext).
+
+	aimedNodeOutsideContext := sdbg node methodNode body statements last.
+
+	self assert: (sdbg outerMostContextOf: sdbg context) pc
+		< (sdbg node methodNode lastPcForNode:
+				 aimedNodeOutsideContext).
+	self assert: (sdbg canStillExecute: aimedNodeOutsideContext)
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsBeforeInAnyContext [
+
+	| sdbg aimedNodeInContext aimedNodeOutsideContext |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithSeveralInstructionsInBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver;
+		stepOver;
+		stepThrough;
+		stepOver.
+
+	aimedNodeInContext := sdbg methodNode body statements first.
+
+	self deny: sdbg pc
+		< (sdbg methodNode lastPcForNode: aimedNodeInContext).
+	self deny: (sdbg canStillExecute: aimedNodeInContext).
+
+	aimedNodeOutsideContext := sdbg node methodNode body statements second.
+
+	self deny: (sdbg outerMostContextOf: sdbg context) pc
+		< (sdbg node methodNode lastPcForNode:
+				 aimedNodeOutsideContext).
+	self deny: (sdbg canStillExecute: aimedNodeOutsideContext)
 ]
 
 { #category : #tests }
@@ -607,76 +676,6 @@ SindarinDebuggerTest >> testSkipAssignmentWithStoreIntoBytecodePushesReplacement
 ]
 
 { #category : #tests }
-SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
-
-	| a scdbg |
- 	a := 1.
- 	scdbg := SindarinDebugger
- 		debug: [ a := a + 2 ].
- 	self assert: a equals: 1.
-
- 	scdbg skip.
- 	scdbg step.
-
- 	self assert: a equals: 1
-]
-
-{ #category : #tests }
-SindarinDebuggerTest >> testSkipSkipsSuperSendBytecodesCorrectly [
-
-	| a scdbg oldValueOfA negatedContext |
-	a := ScaledDecimal newFromNumber: 3 scale: 2.
-	scdbg := SindarinDebugger debug: [ a := a negated ].
-	oldValueOfA := a.
-
-	scdbg
-		step;
-		stepOver;
-		skip.
-	negatedContext := scdbg context.
-	scdbg stepUntil: [ scdbg context == negatedContext ].
-	scdbg stepOver.
-
-	self assert: a equals: oldValueOfA
-]
-
-{ #category : #tests }
-SindarinDebuggerTest >> testSkipDoesNotSkipReturn [
-
-	| a scdbg |
-	scdbg := SindarinDebugger debug: [ a := 1. ^ 42  ].
-	
-	self shouldnt: [ scdbg skip ] raise: SindarinSkippingReturnWarning.
-	self should: [ scdbg skip ] raise: SindarinSkippingReturnWarning
-]
-
-{ #category : #tests }
-SindarinDebuggerTest >> testSkipStepsMethodNodes [
-
-	| scdbg realExecNode realExecPc realTopStack |
-	scdbg := SindarinDebugger debug: [ 
-		         self helperMethodWithBlockWithNoReturn ].
-
-	scdbg step.
-	scdbg stepOver.
-
-	realExecNode := scdbg node.
-	realExecPc := scdbg pc.
-	realTopStack := scdbg topStack.
-
-	scdbg := SindarinDebugger debug: [ 
-		         self helperMethodWithBlockWithNoReturn ].
-
-	scdbg
-		step;
-		skip.
-
-	self assert: scdbg node identicalTo: realExecNode.
-	self assert: scdbg pc identicalTo: realExecPc.
-	self assert: scdbg topStack equals: realTopStack
-]
-
-{ #category : #tests }
 SindarinDebuggerTest >> testSkipBlockNode [
 
 	| scdbg targetContext |
@@ -714,6 +713,76 @@ SindarinDebuggerTest >> testSkipBlockNode [
 
 	self assert: scdbg context identicalTo: targetContext.
 	self assert: scdbg topStack equals: 43
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipDoesNotSkipReturn [
+
+	| a scdbg |
+	scdbg := SindarinDebugger debug: [ a := 1. ^ 42  ].
+	
+	self shouldnt: [ scdbg skip ] raise: SindarinSkippingReturnWarning.
+	self should: [ scdbg skip ] raise: SindarinSkippingReturnWarning
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
+
+	| a scdbg |
+ 	a := 1.
+ 	scdbg := SindarinDebugger
+ 		debug: [ a := a + 2 ].
+ 	self assert: a equals: 1.
+
+ 	scdbg skip.
+ 	scdbg step.
+
+ 	self assert: a equals: 1
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipSkipsSuperSendBytecodesCorrectly [
+
+	| a scdbg oldValueOfA negatedContext |
+	a := ScaledDecimal newFromNumber: 3 scale: 2.
+	scdbg := SindarinDebugger debug: [ a := a negated ].
+	oldValueOfA := a.
+
+	scdbg
+		step;
+		stepOver;
+		skip.
+	negatedContext := scdbg context.
+	scdbg stepUntil: [ scdbg context == negatedContext ].
+	scdbg stepOver.
+
+	self assert: a equals: oldValueOfA
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipStepsMethodNodes [
+
+	| scdbg realExecNode realExecPc realTopStack |
+	scdbg := SindarinDebugger debug: [ 
+		         self helperMethodWithBlockWithNoReturn ].
+
+	scdbg step.
+	scdbg stepOver.
+
+	realExecNode := scdbg node.
+	realExecPc := scdbg pc.
+	realTopStack := scdbg topStack.
+
+	scdbg := SindarinDebugger debug: [ 
+		         self helperMethodWithBlockWithNoReturn ].
+
+	scdbg
+		step;
+		skip.
+
+	self assert: scdbg node identicalTo: realExecNode.
+	self assert: scdbg pc identicalTo: realExecPc.
+	self assert: scdbg topStack equals: realTopStack
 ]
 
 { #category : #'tests - skipping' }
@@ -789,8 +858,27 @@ SindarinDebuggerTest >> testSkipUpToNode [
 	self assert: dbg topStack equals: realExecTopStack
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipUpToNodeDoesNotLoopWhenAimedNodeIsBeforeCurrentNode [
+
+	| sdbg aimedNode nodeBeforeSkip |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithSeveralInstructionsInBlock ].
+	sdbg
+		step;
+		stepOver.
+
+	aimedNode := sdbg node.
+	sdbg stepOver.
+	nodeBeforeSkip := sdbg node.
+
+	sdbg skipUpToNode: aimedNode.
+
+	self assert: sdbg node identicalTo: nodeBeforeSkip
+]
+
 { #category : #helpers }
-SindarinDebuggerTest >> testSkipUpToNodeStopsOnImplicitReturn [
+SindarinDebuggerTest >> testSkipUpToNodeStopsOnImplicitReturnIfAimedNodeCanStillBeExecuted [
 
 	| scdbg implicitReturnPc implicitReturnNode realExecPc realExecNode |
 	scdbg := SindarinDebugger debug: [ 
@@ -821,8 +909,11 @@ SindarinDebuggerTest >> testSkipUpToNodeStopsOnImplicitReturn [
 		stepOver;
 		stepOver;
 		stepOver;
-		stepThrough;
-		skipUpToNode: realExecNode.
+		stepThrough.
+
+	self assert: (scdbg canStillExecute: realExecNode).
+
+	scdbg skipUpToNode: realExecNode.
 
 	self assert: scdbg pc equals: implicitReturnPc.
 	self assert: scdbg node identicalTo: implicitReturnNode

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -835,6 +835,45 @@ SindarinDebuggerTest >> testSkipToPC [
 	self assert: dbg topStack equals: realExecTopStack
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipToPcDoesNotLoopWhenAimedPcIsAfterEndPc [
+
+	| sdbg aimedPc pcBeforeSkip |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithSeveralInstructionsInBlock ].
+	sdbg
+		step;
+		stepOver.
+
+	sdbg stepOver.
+	pcBeforeSkip := sdbg pc.
+	aimedPc := sdbg context endPC + 1.
+
+	sdbg skipToPC: aimedPc.
+
+	self assert: sdbg pc equals: sdbg context endPC.
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipToPcDoesNotLoopWhenAimedPcIsBeforeCurrentPc [
+
+	| sdbg aimedPc pcBeforeSkip |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithSeveralInstructionsInBlock ].
+	sdbg
+		step;
+		stepOver.
+
+	aimedPc := sdbg pc.
+
+	sdbg stepOver.
+	pcBeforeSkip := sdbg pc.
+
+	sdbg skipToPC: aimedPc.
+
+	self assert: sdbg pc equals: pcBeforeSkip.
+]
+
 { #category : #'tests - skipping' }
 SindarinDebuggerTest >> testSkipUpToNode [
 	| dbg realExecPC realValueOfA realExecNode realExecTopStack |

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -661,8 +661,12 @@ SindarinDebugger >> skipThroughNode: aProgramNode [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skipToPC: aPC [
+
 	"Skips execution until program counter reaches aPC."
-	[ self pc >= aPC ] whileFalse: [ self skip ]
+
+	[ [ self pc >= aPC ] whileFalse: [ self skip ] ]
+		on: SindarinSkippingReturnWarning
+		do: [ ^ self ]
 ]
 
 { #category : #'stepping -  skip' }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -121,6 +121,25 @@ SindarinDebugger >> bestNodeFor: anInterval [
 	^self node methodNode bestNodeFor: anInterval
 ]
 
+{ #category : #'ast manipulation' }
+SindarinDebugger >> canStillExecute: aProgramNode [
+
+	"returns true if the last pc mapped to aProgramNode is greater than `self pc` in the right context "
+
+	| lastPcForNode rightContext |
+	rightContext := self context.
+
+	[ 
+	rightContext == rightContext outerMostContext or: [ 
+		rightContext method ast allChildren identityIncludes: aProgramNode ] ] 
+		whileFalse: [ rightContext := rightContext sender ].
+
+	lastPcForNode := (rightContext method ast lastPcForNode: aProgramNode) 
+		                 ifNil: [ 0 ].
+
+	^ rightContext pc < lastPcForNode
+]
+
 { #category : #stackAccess }
 SindarinDebugger >> context [
 	"Returns a reification of the current stack-frame."
@@ -358,6 +377,12 @@ SindarinDebugger >> method [
 	"Returns the method of the current stack-frame."
 
 	^ self context method
+]
+
+{ #category : #accessing }
+SindarinDebugger >> methodNode [ 
+
+	^ self method ast
 ]
 
 { #category : #'accessing - bytes' }
@@ -650,12 +675,16 @@ SindarinDebugger >> skipUpToNode: aProgramNode [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skipUpToNode: aProgramNode skipTargetNode: skipTargetNode [
-	"Skips execution until program counter reaches aProgramNode."
 
-	[ [ self node == aProgramNode ] whileFalse: [ self skip ] ]
-		on: SindarinSkippingReturnWarning 
+	"Skips execution until program counter reaches aProgramNode."
+	[ 
+	[ 
+	self node ~~ aProgramNode and: [ 
+		self canStillExecute: aProgramNode  ] ] whileTrue: [ 
+		self skip ] ]
+		on: SindarinSkippingReturnWarning
 		do: [ ^ self ].
-	aProgramNode isReturn	ifTrue: [ ^ self ].
+	aProgramNode isReturn ifTrue: [ ^ self ].
 	skipTargetNode ifTrue: [ self skip ]
 ]
 


### PR DESCRIPTION
Partially fixes #28.

When we used skipUpTo in a block to skip instructions, the image would freeze, even though it wouldn't if we had used skipUpTo to skip the same instructions outside of a block.

This is partially due to `skipUpTo` not managing errors when the aimed node is not reachable (when, in the context of the node, `context pc` is greater than the last offset mapped to the aimed node.

I fixed it so that skipUpTo doesn't skip anything when this is the case.

I write that it "partially" fixes the issue as this is also because the skipUpToCommand does not select the node the user really wants to skip up to. That is the main reason as there are many tests on the `skipUpToNode` method and they are all green