### PR TITLE
skip  now ignores jumps

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -250,6 +250,17 @@ SindarinDebuggerTest >> helperMethodWithEvaluatedBlock [
 	
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> helperMethodWithIfTrueIfFalse [
+
+	| a |
+	a := true.
+	a
+		ifFalse: [ a := 1 ]
+		ifTrue: [ a := 2 ].
+	a := 3
+]
+
 { #category : #helpers }
 SindarinDebuggerTest >> helperMethodWithSeveralInstructionsInBlock [
 
@@ -883,6 +894,59 @@ SindarinDebuggerTest >> testSkipToPcDoesNotLoopWhenAimedPcIsBeforeCurrentPc [
 	sdbg skipToPC: aimedPc.
 
 	self assert: sdbg pc equals: pcBeforeSkip.
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipUpToIgnoresJumps [
+
+	| sdbg aimedNode aimedPC a |
+	sdbg := SindarinDebugger debug: [ self helperMethodWithIfTrueIfFalse ].
+
+	sdbg step.
+
+	aimedNode := sdbg methodNode statements second arguments first
+		             statements first.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	a := sdbg temporaryNamed: #a.
+
+	self assert: a isNil.
+
+	sdbg skipUpToNode: aimedNode.
+
+	self
+		assert: a isNil;
+		assert: sdbg node identicalTo: aimedNode;
+		assert: sdbg pc equals: aimedPC.
+
+	aimedNode := sdbg methodNode statements second arguments second
+		             statements first.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	a := sdbg temporaryNamed: #a.
+
+	self assert: a isNil.
+
+	sdbg skipUpToNode: aimedNode .
+
+	self
+		assert: a isNil;
+		assert: sdbg node identicalTo: aimedNode;
+		assert: sdbg pc equals: aimedPC.
+
+	aimedNode := sdbg methodNode statements third.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	a := sdbg temporaryNamed: #a.
+
+	self assert: a isNil.
+
+	sdbg skipUpToNode: aimedNode.
+
+	self
+		assert: a isNil;
+		assert: sdbg node identicalTo: aimedNode;
+		assert: sdbg pc equals: aimedPC
 ]
 
 { #category : #'tests - skipping' }

--- a/Sindarin/Context.extension.st
+++ b/Sindarin/Context.extension.st
@@ -2,15 +2,17 @@ Extension { #name : #Context }
 
 { #category : #'*Sindarin' }
 Context >> stepToSendOrReturnOrJump [
+
 	"Simulate the execution of bytecodes until either sending a message or 
 	returning a value to the receiver (that is, until switching contexts)."
 
 	| stream context |
-	stream := InstructionStream on: method pc: pc.	
-	[ self isDead or: [ stream willSend or: [ stream willReturn or: [ stream willStore or: [ stream willCreateBlock or: [ stream willJumpIfFalse or:[ stream willJumpIfTrue or: [ stream willJumpTo ] ] ] ] ] ] ] ]
-		whileFalse: [
+	stream := InstructionStream on: method pc: pc.
+	[ 
+	self isDead or: [ 
+		stream willSendOrReturnOrStoreOrCreateBlock or: [ stream willJump ] ] ] 
+		whileFalse: [ 
 			context := stream interpretNextInstructionFor: self.
-			context == self ifFalse: [
-				"Caused by mustBeBoolean handling"
-				^context ]]
+			context == self ifFalse: [ "Caused by mustBeBoolean handling" 
+				^ context ] ]
 ]

--- a/Sindarin/Context.extension.st
+++ b/Sindarin/Context.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #Context }
+
+{ #category : #'*Sindarin' }
+Context >> stepToSendOrReturnOrJump [
+	"Simulate the execution of bytecodes until either sending a message or 
+	returning a value to the receiver (that is, until switching contexts)."
+
+	| stream context |
+	stream := InstructionStream on: method pc: pc.	
+	[ self isDead or: [ stream willSend or: [ stream willReturn or: [ stream willStore or: [ stream willCreateBlock or: [ stream willJumpIfFalse or:[ stream willJumpIfTrue or: [ stream willJumpTo ] ] ] ] ] ] ] ]
+		whileFalse: [
+			context := stream interpretNextInstructionFor: self.
+			context == self ifFalse: [
+				"Caused by mustBeBoolean handling"
+				^context ]]
+]

--- a/Sindarin/DebugSession.extension.st
+++ b/Sindarin/DebugSession.extension.st
@@ -4,3 +4,22 @@ Extension { #name : #DebugSession }
 DebugSession >> asSindarinDebugSession [
 	^ SindarinDebugSession new debugSession: self
 ]
+
+{ #category : #'*Sindarin' }
+DebugSession >> stepToFirstInterestingBytecodeWithJumpIn: aProcess [
+	"After a restart of a method activation step to the first 
+	bytecode instruction that is of interest for the debugger.
+	
+	In this case step until a bytecode that causes a context switch,
+	as otherwise one will have to press may time step into without 
+	seeing any visible results."
+	
+	"If we are are stepping into a quick method,
+	make sure that we step correctly over the first primitive bytecode"
+	| suspendedContext |
+	suspendedContext := aProcess suspendedContext.
+	(suspendedContext method isQuick and: [ suspendedContext pc == suspendedContext method initialPC ])
+		ifTrue: [ ^ suspendedContext updatePCForQuickPrimitiveRestart ].
+	
+	^ aProcess stepToSendOrReturnOrJump
+]

--- a/Sindarin/InstructionStream.extension.st
+++ b/Sindarin/InstructionStream.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #InstructionStream }
 
 { #category : #'*Sindarin' }
+InstructionStream >> willJump [
+	"Answer whether the next bytecode will jump."
+
+	^ self willJumpIfFalse or:[ self willJumpIfTrue or: [ self willJumpTo ] ]
+]
+
+{ #category : #'*Sindarin' }
 InstructionStream >> willJumpIfFalse [
 	"Answer whether the next bytecode is a jump-if-false."
 
@@ -19,4 +26,13 @@ InstructionStream >> willJumpTo [
 	"Answer whether the next bytecode is a jump-if-false."
 
 	^ self method encoderClass isJumpAt: pc in: self method
+]
+
+{ #category : #'*Sindarin' }
+InstructionStream >> willSendOrReturnOrStoreOrCreateBlock [
+
+	"Answer whether the next bytecode will be interesting for the debugger to stop."
+
+	^ self willSend or: [ 
+		  self willReturn or: [ self willStore or: [ self willCreateBlock ] ] ]
 ]

--- a/Sindarin/InstructionStream.extension.st
+++ b/Sindarin/InstructionStream.extension.st
@@ -1,0 +1,22 @@
+Extension { #name : #InstructionStream }
+
+{ #category : #'*Sindarin' }
+InstructionStream >> willJumpIfFalse [
+	"Answer whether the next bytecode is a jump-if-false."
+
+	^ self method encoderClass isBranchIfFalseAt: pc in: self method
+]
+
+{ #category : #'*Sindarin' }
+InstructionStream >> willJumpIfTrue [
+	"Answer whether the next bytecode is a jump-if-false."
+
+	^ self method encoderClass isBranchIfTrueAt: pc in: self method
+]
+
+{ #category : #'*Sindarin' }
+InstructionStream >> willJumpTo [
+	"Answer whether the next bytecode is a jump-if-false."
+
+	^ self method encoderClass isJumpAt: pc in: self method
+]

--- a/Sindarin/Process.extension.st
+++ b/Sindarin/Process.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #Process }
+
+{ #category : #'*Sindarin' }
+Process >> stepToSendOrReturnOrJump [
+
+	^Processor activeProcess
+		evaluate: [suspendedContext := suspendedContext stepToSendOrReturnOrJump]
+		onBehalfOf: self
+]

--- a/Sindarin/RBAssignmentNode.extension.st
+++ b/Sindarin/RBAssignmentNode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RBAssignmentNode }
+
+{ #category : #'*Sindarin' }
+RBAssignmentNode >> skipWithDebugger: aSindarinDebugger [
+
+	aSindarinDebugger skipAssignmentNodeCompletely 
+]

--- a/Sindarin/RBBlockNode.extension.st
+++ b/Sindarin/RBBlockNode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RBBlockNode }
+
+{ #category : #'*Sindarin' }
+RBBlockNode >> skipWithDebugger: aSindarinDebugger [
+
+	aSindarinDebugger skipBlockNode 
+]

--- a/Sindarin/RBMessageNode.extension.st
+++ b/Sindarin/RBMessageNode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RBMessageNode }
+
+{ #category : #'*Sindarin' }
+RBMessageNode >> skipWithDebugger: aSindarinDebugger [
+
+	aSindarinDebugger skipMessageNode 
+]

--- a/Sindarin/RBProgramNode.extension.st
+++ b/Sindarin/RBProgramNode.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #RBProgramNode }
+
+{ #category : #'*Sindarin' }
+RBProgramNode >> skipWithDebugger: aSindarinDebugger [
+
+	aSindarinDebugger step
+
+	
+]

--- a/Sindarin/RBReturnNode.extension.st
+++ b/Sindarin/RBReturnNode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RBReturnNode }
+
+{ #category : #'*Sindarin' }
+RBReturnNode >> skipWithDebugger: aSindarinDebugger [
+
+	aSindarinDebugger skipReturnNode
+]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -557,22 +557,18 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skip [
 
-	| nextBytecode instructionStream |
+	| instructionStream |
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
 	self node isAssignment ifTrue: [ ^ self skipAssignmentNodeCompletely ].
 	"We need to treat jumps before messages because if it is associated to a message node, it would pop the arguments of the message, that aren't on the stack if they are jumps"
 	instructionStream := self context instructionStream.
-	(instructionStream willJumpTo or: [ 
-		 instructionStream willJumpIfFalse or: [ 
-			 instructionStream willJumpIfTrue ] ]) ifTrue: [ ^ self skipJump ].
+	(instructionStream willJump) ifTrue: [ ^ self skipJump ].
 	self node isMessage ifTrue: [ ^ self skipMessageNode ].
 	self node isMethod ifTrue: [ ^ self step ].
 	self node isBlock ifTrue: [ ^ self skipBlockNode ].
-	nextBytecode := self currentBytecode detect: [ :each | 
-		                each offset = self pc ].
 
 	(self node isReturn or: [ 
-		 nextBytecode bytes first between: 88 and: 94 ]) ifTrue: [ 
+		 instructionStream willReturn ]) ifTrue: [ 
 		^ self skipReturnNode ].
 
 	self node isSequence ifTrue: [ ^ self step ]
@@ -632,6 +628,7 @@ SindarinDebugger >> skipJump [
 
 	| instructionStream nextBytecode |
 	instructionStream := self context instructionStream.
+	"If the next bytecode is a jumpTrue: or a jumpFalse: bytecode, then it expects one argument on the stack. As we skip the jump bytecode, we pop it."
 	(instructionStream willJumpIfFalse or: [ 
 		 instructionStream willJumpIfTrue ]) ifTrue: [ self context pop ].
 	nextBytecode := self currentBytecode detect: [ :each | 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -556,18 +556,25 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skip [
-	
-	| nextBytecode |
+
+	| nextBytecode instructionStream |
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
 	self node isAssignment ifTrue: [ ^ self skipAssignmentNodeCompletely ].
-  self node isMessage ifTrue: [ ^ self skipMessageNode ].
-  self node isMethod ifTrue: [ ^ self step ].
-  self node isBlock ifTrue: [ self skipBlockNode ].
+	"We need to treat jumps before messages because if it is associated to a message node, it would pop the arguments of the message, that aren't on the stack if they are jumps"
+	instructionStream := self context instructionStream.
+	(instructionStream willJumpTo or: [ 
+		 instructionStream willJumpIfFalse or: [ 
+			 instructionStream willJumpIfTrue ] ]) ifTrue: [ ^ self skipJump ].
+	self node isMessage ifTrue: [ ^ self skipMessageNode ].
+	self node isMethod ifTrue: [ ^ self step ].
+	self node isBlock ifTrue: [ ^ self skipBlockNode ].
 	nextBytecode := self currentBytecode detect: [ :each | 
 		                each offset = self pc ].
+
 	(self node isReturn or: [ 
 		 nextBytecode bytes first between: 88 and: 94 ]) ifTrue: [ 
 		^ self skipReturnNode ].
+
 	self node isSequence ifTrue: [ ^ self step ].
 
 	self skipWith: nil
@@ -591,7 +598,7 @@ SindarinDebugger >> skipAssignmentNodeCompletely [
 	"Increase the pc to go over the assignment"
 	self context pc: self context pc + currentBytecode bytes size.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
-	self debugSession stepToFirstInterestingBytecodeIn:
+	self debugSession stepToFirstInterestingBytecodeWithJumpIn:
 		self debugSession interruptedProcess
 ]
 
@@ -604,18 +611,36 @@ SindarinDebugger >> skipAssignmentNodeWith: replacementValue [
 	self step.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
 	self debugSession
-		stepToFirstInterestingBytecodeIn: self debugSession interruptedProcess
+		stepToFirstInterestingBytecodeWithJumpIn: self debugSession interruptedProcess
 ]
 
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skipBlockNode [
 
 	| nextBytecode |
-	nextBytecode := self currentBytecode detect: [ :bytecode | bytecode offset = self pc ].
-	
+	nextBytecode := self currentBytecode detect: [ :bytecode | 
+		                bytecode offset = self pc ].
+
 	self context pc: self pc + nextBytecode bytes size.
-	
-	self context push: nil
+
+	self context push: nil.
+
+	self debugSession stepToFirstInterestingBytecodeWithJumpIn:
+		self debugSession interruptedProcess
+]
+
+{ #category : #'stepping - skip' }
+SindarinDebugger >> skipJump [
+
+	| instructionStream nextBytecode |
+	instructionStream := self context instructionStream.
+	(instructionStream willJumpIfFalse or: [ 
+		 instructionStream willJumpIfTrue ]) ifTrue: [ self context pop ].
+	nextBytecode := self currentBytecode detect: [ :each | 
+		                each offset = self pc ].
+	self context pc: self context pc + nextBytecode bytes size.
+	self debugSession stepToFirstInterestingBytecodeWithJumpIn:
+		self debugSession interruptedProcess
 ]
 
 { #category : #'stepping - skip' }
@@ -626,7 +651,7 @@ SindarinDebugger >> skipMessageNode [
 	"Increase the pc to go over the message send"
 	self context pc: self context pc + self nextBytecode bytes size.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
-	self debugSession stepToFirstInterestingBytecodeIn:
+	self debugSession stepToFirstInterestingBytecodeWithJumpIn:
 		self debugSession interruptedProcess
 ]
 
@@ -641,7 +666,7 @@ SindarinDebugger >> skipMessageNodeWith: replacementValue [
 	"Increase the pc to go over the message send"
 	self context pc: self context pc + self nextBytecode bytes size.
 	"Execute bytecodes the debugger usually executes without stopping the execution (for example popping the return value of the just executed message send if it is not used afterwards)"
-	self debugSession stepToFirstInterestingBytecodeIn:
+	self debugSession stepToFirstInterestingBytecodeWithJumpIn:
 		self debugSession interruptedProcess
 ]
 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -575,9 +575,7 @@ SindarinDebugger >> skip [
 		 nextBytecode bytes first between: 88 and: 94 ]) ifTrue: [ 
 		^ self skipReturnNode ].
 
-	self node isSequence ifTrue: [ ^ self step ].
-
-	self skipWith: nil
+	self node isSequence ifTrue: [ ^ self step ]
 ]
 
 { #category : #'stepping -  skip' }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -558,20 +558,13 @@ SindarinDebugger >> sindarinSession: aSindarinDebugSession [
 SindarinDebugger >> skip [
 
 	| instructionStream |
-	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
-	self node isAssignment ifTrue: [ ^ self skipAssignmentNodeCompletely ].
-	"We need to treat jumps before messages because if it is associated to a message node, it would pop the arguments of the message, that aren't on the stack if they are jumps"
 	instructionStream := self context instructionStream.
-	(instructionStream willJump) ifTrue: [ ^ self skipJump ].
-	self node isMessage ifTrue: [ ^ self skipMessageNode ].
-	self node isMethod ifTrue: [ ^ self step ].
-	self node isBlock ifTrue: [ ^ self skipBlockNode ].
+	"We need to treat jumps before messages because if it is associated to a message node, it would pop the arguments of the message, that aren't on the stack if they are jumps"
+	instructionStream willJump ifTrue: [ ^ self skipJump ].
+	"A return bytecode can be on any node so have to treat it here systematically"
+	instructionStream willReturn ifTrue: [ ^ self skipReturnNode ].
 
-	(self node isReturn or: [ 
-		 instructionStream willReturn ]) ifTrue: [ 
-		^ self skipReturnNode ].
-
-	self node isSequence ifTrue: [ ^ self step ]
+	self node skipWithDebugger: self
 ]
 
 { #category : #'stepping -  skip' }


### PR DESCRIPTION
Fixes #51.

skip used to step over jump bytecodes. Notably, if a comparison before a `ifTrue:ifFalse:`message was skipped, it used to skip the comparison and then step the jumpIfFalse bytecode. As this bytecode expected a boolean on the stack (the result of the comparison that has been skipped) and as the result on the stack is (probably) not a boolean, an exception `MustBeBoolean` was raised and  was not handled. As a result, `skipUpTo` entered an infinite loop because we would never reach the aimed node.

Now, skips stops on jump bytecodes (notably on `ifTrue:ifFalse` messages) and manages these bytecodes separately: it pops the argument if it has one (this is the case for jumpTrue: and jumpFalse: bytecodes) and it simply does not execute the jump bytecode. Then, it steps to the first next interesting bytecode (I reimplemented this function in `DebugSession` to stop on jump bytecodes