### PR TITLE
[New Feature] Adding a JumpToCaret command to move the caret back and forth in the debugger suspended context without executing anything in between

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -527,6 +527,26 @@ SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testChangingPcToNonExistingBytecodeOffsetGoesToPreviousPcWithExistingBytecodeOffset [
+
+	| scdbg newPc newNode |
+	scdbg := SindarinDebugger debug: [ 
+		         self helperMethodWithDoubleAssignment ].
+
+	scdbg step.
+	"pc of b := 1 from `a:= b:= 1` This is associated to the pc of a storeIntoTemp bytecode, of length 2 bytes. So we add 1 to get a pc that is in the middle of the bytecode"
+	newNode := scdbg methodNode statements first value.
+	newPc := (scdbg methodNode firstPcForNode: newNode) + 1.
+
+	self assert: (scdbg methodNode sourceNodeForPC: newPc) identicalTo: newNode.
+	
+	scdbg pc: newPc.
+
+	self assert: scdbg node equals: newNode.
+	self assert: scdbg pc equals: newPc - 1.
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testContext [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod15 ].

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -911,6 +911,156 @@ SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotInMethod [
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedBlockToOuterContext [
+
+	| oldNode sdbg aimedNode oldContext aimedPC methodNode |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithNotEvaluatedBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+
+	"stops on block creation"
+	oldNode := sdbg node.
+	oldContext := sdbg context.
+	methodNode := sdbg methodNode.
+
+	"We want to move to node 'a + 1' in [a := a +1]"
+	aimedNode := sdbg methodNode statements second statements first value.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	self assert: aimedPC isNil.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	sdbg moveToNode: aimedNode.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	self assert: sdbg context home identicalTo: oldContext.
+	self
+		assert: sdbg methodNode
+		identicalTo: methodNode statements second.
+
+	sdbg stepOver.
+
+	"2 is going to be assigned to a"
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+	self assert: sdbg topStack equals: 2.
+
+	sdbg moveToNode: methodNode statements third.
+	"We jump to node outside of block"
+	self assert: sdbg methodNode identicalTo: methodNode.
+	self assert: sdbg node identicalTo: methodNode statements third.
+	"We went back to the home context"
+	self assert: sdbg context identicalTo: oldContext.
+	"2 has not been assigned to a"
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+	self assert: sdbg topStack equals: 1
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToHomeContext [
+
+	| oldNode sdbg aimedNode oldContext aimedPC methodNode |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithEmbeddedBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+
+	"stops on block creation"
+	oldNode := sdbg node.
+	oldContext := sdbg context.
+	methodNode := sdbg methodNode.
+
+	"We want to move to node 'a + 1' in [a := a +1]"
+	aimedNode := sdbg methodNode statements second statements second statements first value.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	self assert: aimedPC isNil.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	sdbg moveToNode: aimedNode.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	self assert: sdbg context home identicalTo: oldContext.
+	self
+		assert: sdbg methodNode
+		identicalTo: methodNode statements second statements second.
+
+	sdbg stepOver.
+
+	"2 is going to be assigned to a"
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+	self assert: sdbg topStack equals: 2.
+
+	sdbg moveToNode: methodNode statements third.
+	"We jump to node in home context of embedded block"
+	self assert: sdbg methodNode identicalTo: methodNode.
+	self assert: sdbg node identicalTo: methodNode statements third.
+	"We went back to the home context"
+	self assert: sdbg context identicalTo: oldContext.
+	"2 has not been assigned to a"
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+	self assert: sdbg topStack equals: 1
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToNodeThatIsNotInHomeContext [
+
+	| oldNode oldPC sdbg aimedNode oldContext aimedPC methodNode |
+	sdbg := SindarinDebugger debug: [ self helperMethodWithEmbeddedBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+
+	"stops on block creation"
+	oldNode := sdbg node.
+	oldContext := sdbg context.
+	methodNode := sdbg methodNode.
+
+	"We want to move to node 'a + 1' in [a := a +1]"
+	aimedNode := sdbg methodNode statements second statements second
+		             statements first value.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	self assert: aimedPC isNil.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	sdbg moveToNode: aimedNode.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	self assert: sdbg context home identicalTo: oldContext.
+	self
+		assert: sdbg methodNode
+		identicalTo: methodNode statements second statements second.
+
+	sdbg stepOver.
+
+	"2 is going to be assigned to a"
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+	self assert: sdbg topStack equals: 2.
+
+	oldNode := sdbg node.
+	oldPC := sdbg pc.
+	oldContext := sdbg context.
+
+	sdbg moveToNode: (RBLiteralValueNode value: 1).
+	"We jump to node in home context of embedded block"
+	self assert: sdbg node identicalTo: oldNode.
+	"We went back to the home context"
+	self assert: sdbg context identicalTo: oldContext.
+	"2 has not been assigned to a"
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+	self assert: sdbg topStack equals: 2
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBlockHasBeenCreated [
 
 	| oldNode sdbg aimedNode oldContext aimedPC |

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -389,7 +389,7 @@ SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsBeforeInAnyContext [
 	self deny: (sdbg canStillExecute: aimedNodeOutsideContext)
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : #tests }
 SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnStack [
 
 	| scdbg newPc newNode expectedStackTop |
@@ -397,6 +397,7 @@ SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnSt
 
 	scdbg
 		step;
+		stepOver;
 		stepOver.
 	"pc of '3' asInteger"
 	newNode := scdbg node.
@@ -404,12 +405,39 @@ SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnSt
 	expectedStackTop := scdbg topStack.
 	scdbg
 		stepOver;
-		stepOver;
 		stepOver.
 
 	self assert: (scdbg temporaryNamed: #a) equals: 5.
 
 	scdbg pc: newPc.
+
+	self assert: (scdbg temporaryNamed: #a) equals: 5.
+	self assert: scdbg node equals: newNode.
+	self assert: scdbg pc equals: newPc.
+	self assert: scdbg topStack equals: expectedStackTop
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
+
+	| scdbg newPc newNode expectedStackTop |
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver;
+		stepOver.
+	
+	self shouldnt: [ scdbg pc: scdbg method initialPC ] raise: NotValidPcError.
+	
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver;
+		stepOver.
+
+	self should: [ scdbg pc: scdbg method initialPC - 1 ] raise: NotValidPcError.
 
 	self assert: (scdbg temporaryNamed: #a) equals: 5.
 	self assert: scdbg node equals: newNode.

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -781,6 +781,33 @@ SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNode [
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNodeThatDoesNotHaveAssociatedPC [
+
+	| scdbg newPc newNode realPC realNode |
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver.
+	"pc of a := 5"
+	newNode := scdbg methodNode.
+	newPc := scdbg methodNode firstPcForNode: scdbg methodNode.
+
+
+	self assert: newPc isNil.
+
+	scdbg moveToNode: newNode.
+
+	realPC := scdbg pc.
+	realNode := scdbg node.
+
+	self assert: scdbg pc equals: scdbg method endPC.
+	self
+		assert: scdbg node
+		identicalTo: (scdbg methodNode sourceNodeForPC: scdbg pc)
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeInMethod [
 
 	| oldNode sdbg aimedNode |

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -250,6 +250,16 @@ SindarinDebuggerTest >> helperMethodWithDoubleAssignment [
 ]
 
 { #category : #helpers }
+SindarinDebuggerTest >> helperMethodWithEmbeddedBlock [
+
+	| a |
+	a := 1.
+	[ :each | a := a + each. [ a := a + 1 ]. a * 42 ].
+	a := a + 2.
+	^ a * 42
+]
+
+{ #category : #helpers }
 SindarinDebuggerTest >> helperMethodWithEvaluatedBlock [
 
 	| a b block |
@@ -1056,6 +1066,62 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableThatHasNoAssoci
 		deny: realNode isLiteralNode;
 		deny: realNode isVariable;
 		deny: (sdbg methodNode pcsForNode: realNode) isEmpty
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsNonInlinedAndEmbeddedInNonInlinedBlock [
+
+	| oldNode sdbg aimedNode oldContext aimedPC methodNode |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithEmbeddedBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver. 
+		
+	"stops on outer block creation"
+	oldNode := sdbg node.
+	oldContext := sdbg context.
+	methodNode := sdbg methodNode.
+	
+	"We want to move to node 'a + 1' in [a := a +1] (embedded block)"
+	aimedNode := sdbg methodNode statements second statements second statements first value.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+	
+	self assert: aimedPC isNil.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	sdbg moveToNode: aimedNode.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	self assert: sdbg node identicalTo: aimedNode.
+	self assert: sdbg context home identicalTo: oldContext.
+	self assert: sdbg methodNode identicalTo: methodNode statements second statements second.
+
+	sdbg
+		stepOver;
+		stepOver;
+		stepOver.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 2.
+
+	"When you perform a stepOver, you quit the block and continue after the embedded block creation in the embedding block context"
+	self assert: sdbg methodNode identicalTo: methodNode statements second.
+	self assert: sdbg node identicalTo: methodNode statements second statements third.
+	self assert: sdbg context sender identicalTo: oldContext.
+	
+	sdbg
+		stepOver;
+		stepOver;
+		stepOver.
+		
+	self assert: (sdbg temporaryNamed: #a) equals: 2.
+
+	"When you perform stepOver again, you quit the embedding block and continue after the embedding block creation in the old context"
+	self assert: sdbg methodNode identicalTo: methodNode.
+	self assert: sdbg node identicalTo: sdbg methodNode statements third.
+	self assert: sdbg context identicalTo: oldContext.
 ]
 
 { #category : #tests }

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -941,7 +941,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBloc
 	self assert: (sdbg temporaryNamed: #a) equals: 2.
 
 	"When you perform a stepOver, you quit the block and continue right where you were before moving to caret"
-	self assert: sdbg node identicalTo: oldNode.
+	self assert: sdbg node identicalTo: sdbg methodNode statements third value.
 	self assert: sdbg context identicalTo: oldContext.
 	self assert: sdbg topStack equals: 2
 ]

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -1058,7 +1058,9 @@ SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToNodeThatI
 	oldPC := sdbg pc.
 	oldContext := sdbg context.
 
-	sdbg moveToNode: (RBLiteralValueNode value: 1).
+	self
+		should: [ sdbg moveToNode: (RBLiteralValueNode value: 1) ]
+		raise: NodeNotInASTError.
 	"We jump to node in home context of embedded block"
 	self assert: sdbg node identicalTo: oldNode.
 	"We went back to the home context"

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -669,6 +669,154 @@ SindarinDebuggerTest >> testMethod [
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeInTheMiddleOfStatementSkipsTheBeginningOfStatement [
+
+	| scdbg newPc newNode expectedStackTop |
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver;
+		stepOver;
+		stepOver.
+	"pc of Point x: y:"
+	newNode := scdbg node.
+	newPc := scdbg pc.
+	expectedStackTop := scdbg topStack.
+
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver.
+	"pc of a := 5"
+	
+	self assert: (scdbg temporaryNamed: #a) equals: 1.
+
+	scdbg moveToNode: newNode.
+	"It should skip the assignment a:=5 AND skip the beginning of the statement ('3' asInteger)"
+
+	self assert: (scdbg temporaryNamed: #a) equals: 1.
+	self assert: scdbg node equals: newNode.
+	self assert: scdbg pc equals: newPc.
+	self deny: scdbg topStack equals: expectedStackTop.
+	self assert: scdbg topStack equals: '3' "topStack is nil because the message send asInteger to the receiver '3' has been skipped"
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeKeepsSameStateAndPushesCorrectElementsOnStack [
+
+	| scdbg newPc newNode expectedStackTop |
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver.
+	"pc of a := 5"
+	newNode := scdbg node.
+	newPc := scdbg pc.
+	expectedStackTop := scdbg topStack.
+	scdbg
+		stepOver;
+		stepOver.
+
+	self assert: (scdbg temporaryNamed: #a) equals: 5.
+
+	scdbg moveToNode: newNode.
+
+	self assert: (scdbg temporaryNamed: #a) equals: 5.
+	self assert: scdbg node equals: newNode.
+	self assert: scdbg pc equals: newPc.
+	self assert: scdbg topStack equals: expectedStackTop
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeInMethod [
+
+	| oldNode sdbg aimedNode |
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg
+		step;
+		stepOver.
+	aimedNode := sdbg node.
+	sdbg
+		stepOver;
+		stepOver.
+	oldNode := sdbg node.
+	self
+		shouldnt: [ sdbg moveToNode: aimedNode ] raise: NodeNotInASTError;
+		assert: sdbg node equals: aimedNode.
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+	oldNode := sdbg node.
+	self
+		should: [ sdbg moveToNode: (RBLiteralValueNode value: 1) ]
+		raise: NodeNotInASTError;
+		assert: sdbg node equals: oldNode
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotInMethod [
+
+	| oldNode sdbg |
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+	oldNode := sdbg node.
+	self
+		shouldnt: [ sdbg moveToNode: sdbg methodNode statements last ]
+		raise: NodeNotInASTError;
+		deny: sdbg node equals: oldNode.
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+	oldNode := sdbg node.
+	self
+		should: [ sdbg moveToNode: (RBLiteralValueNode value: 2) ]
+		raise: NodeNotInASTError;
+		assert: sdbg node equals: oldNode
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableExecutesAssociatedBytecodesBecauseRelatedToStack [
+
+	| oldNode sdbg aimedNode siblingsAfterAimedNode indexOfAimedNode realNode indexOfRealNode |
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg step.
+	oldNode := sdbg node.
+	"This is the literal value node 5 from `Point x: 5 y: '3' asInteger"
+	aimedNode := sdbg methodNode statements last value receiver.
+	indexOfAimedNode := sdbg methodNode allChildren indexOf: aimedNode.
+	siblingsAfterAimedNode := sdbg methodNode allChildren 
+		                          withIndexSelect: [ :value :index | 
+		                          index > indexOfAimedNode ].
+
+	self deny: (sdbg methodNode pcsForNode: aimedNode) isEmpty.
+	self assert: aimedNode isVariable.
+
+	sdbg moveToNode: aimedNode.
+
+	realNode := sdbg node.
+	indexOfRealNode := siblingsAfterAimedNode indexOf: realNode.
+
+	self deny: realNode identicalTo: aimedNode.
+	siblingsAfterAimedNode
+		from: 1
+		to: indexOfRealNode - 1
+		do: [ :each | 
+		self assert: (each isVariable or: [ each isLiteralNode ]) ].
+
+	self deny: (realNode isLiteralNode or: [ realNode isVariable ])
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testNode [
 	| node scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod1 ].

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -1078,6 +1078,41 @@ SindarinDebuggerTest >> testStack [
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testStatementNodeContaining [
+
+	| sdbg |
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg step; stepOver; stepOver; stepOver. "pc of Point x: y:"
+	
+	self assert: (sdbg statementNodeContaining: sdbg node) identicalTo: sdbg methodNode statements last
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testStatementNodeContainingReturnsStatementNodeThatContainsTheIdenticalSubtree [
+
+	| sdbg |
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg step.
+
+	"1 is in the tree but it should return its parent only if we provide the exact literal node"
+	self
+		should: [ sdbg statementNodeContaining: (RBLiteralNode value: 1) ]
+		raise: NodeNotInASTError
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testStatementNodeContainingWhenNodeIsNotInAST [
+
+	| sdbg |
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg step.
+
+	self
+		should: [ sdbg statementNodeContaining: (RBLiteralNode value: 2) ]
+		raise: NodeNotInASTError
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testStep [
 	| node scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod13 ].

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -390,6 +390,27 @@ SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsBeforeInAnyContext [
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testChangingPcAssociatedToMethodOrSequenceNodeKeepsStackAsItIs [
+
+	| scdbg newPc newNode expectedStackTop |
+	scdbg := SindarinDebugger debug: [ 
+		         self helperMethodWithDoubleAssignment ].
+
+	scdbg
+		step;
+		stepOver.
+	newNode := scdbg methodNode.
+	newPc := scdbg methodNode firstPcForNode: newNode.
+	expectedStackTop := scdbg topStack.
+
+	scdbg pc: newPc.
+
+	self assert: scdbg node equals: newNode.
+	self assert: scdbg pc equals: newPc.
+	self assert: scdbg topStack equals: expectedStackTop
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testChangingPcInTheMiddleOfStatementSkipsTheBeginningOfStatement [
 
 	| scdbg newPc newNode expectedStackTop |

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -273,7 +273,7 @@ SindarinDebuggerTest >> helperMethodWithIfTrueBlock [
 SindarinDebuggerTest >> helperMethodWithNotEvaluatedBlock [
 
 	| a |
-	a := 0.
+	a := 1.
 	[ a := a + 1 ].
 	a := a + 2.
 	^ a * 42
@@ -914,38 +914,36 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBloc
 
 	sdbg moveToNode: sdbg methodNode statements first.
 
-	"It is going to execute the comparison a = 2"
+	"It is going to execute the comparison a := 1"
 	oldNode := sdbg node.
 	oldContext := sdbg context.
 
-	"We want to enter the block, to get to execute a:=3"
+	"We want to enter the block, to get to execute a + 1 in the block"
 	aimedNode := sdbg methodNode statements second body statements first
 		             value.
 	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
 
 	self assert: aimedPC isNil.
-	self assert: (sdbg temporaryNamed: #a) equals: 0.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
 
 	sdbg moveToNode: aimedNode.
 
-	self assert: (sdbg temporaryNamed: #a) equals: 0.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
 
 	self assert: sdbg node identicalTo: aimedNode.
 	self assert: sdbg context sender identicalTo: oldContext.
 
 	sdbg
 		stepOver;
-		stepOver.
-
-	self assert: (sdbg temporaryNamed: #a) equals: 1.
-
-	sdbg
-		stepOver;
 		stepOver;
 		stepOver.
-	"When you perform a stepOver, you quit the block and continue just after the ifTrue: message"
-	self assert: (sdbg temporaryNamed: #a) equals: 3.
-	self assert: sdbg topStack equals: 42
+
+	self assert: (sdbg temporaryNamed: #a) equals: 2.
+
+	"When you perform a stepOver, you quit the block and continue right where you were before moving to caret"
+	self assert: sdbg node identicalTo: oldNode.
+	self assert: sdbg context identicalTo: oldContext.
+	self assert: sdbg topStack equals: 2
 ]
 
 { #category : #tests }

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -1115,10 +1115,54 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBloc
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBlockHasBeenCreatedBackward [
+
+	| oldNode sdbg aimedNode oldContext aimedPC |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithNotEvaluatedBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver;
+		stepOver;
+		stepOver.
+
+	"It is going to execute a := a + 2"
+	oldNode := sdbg node.
+	oldContext := sdbg context.
+
+	"We want to enter the block, to get to execute a + 1 in the block"
+	aimedNode := sdbg methodNode statements second body statements first
+		             value.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	self assert: aimedPC isNil.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	sdbg moveToNode: aimedNode.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	self assert: sdbg node identicalTo: aimedNode.
+	self assert: sdbg context sender identicalTo: oldContext.
+
+	sdbg
+		stepOver;
+		stepOver;
+		stepOver.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 2.
+
+	"When you perform a stepOver, you quit the block and continue right where you were before moving to caret"
+	self assert: sdbg node identicalTo: oldNode value.
+	self assert: sdbg context identicalTo: oldContext.
+	self assert: sdbg topStack equals: 2
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInIfTrueIfFalseBlock [
 
 	| oldNode sdbg aimedNode oldContext aimedPC |
-	self skip.
 	sdbg := SindarinDebugger debug: [ self helperMethodWithIfTrueBlock ].
 	sdbg
 		step;

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -261,6 +261,25 @@ SindarinDebuggerTest >> helperMethodWithEvaluatedBlock [
 ]
 
 { #category : #helpers }
+SindarinDebuggerTest >> helperMethodWithIfTrueBlock [
+
+	| a |
+	a := 1.
+	a = 2 ifTrue: [ a := 3 ].
+	a := 4
+]
+
+{ #category : #helpers }
+SindarinDebuggerTest >> helperMethodWithNotEvaluatedBlock [
+
+	| a |
+	a := 0.
+	[ a := a + 1 ].
+	a := a + 2.
+	^ a * 42
+]
+
+{ #category : #helpers }
 SindarinDebuggerTest >> helperMethodWithSeveralInstructionsInBlock [
 
 	| a b block |
@@ -879,6 +898,93 @@ SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotInMethod [
 		should: [ sdbg moveToNode: (RBLiteralValueNode value: 2) ]
 		raise: NodeNotInASTError;
 		assert: sdbg node equals: oldNode
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBlockHasBeenCreated [
+
+	| oldNode sdbg aimedNode oldContext aimedPC |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithNotEvaluatedBlock ].
+	sdbg
+		step;
+		stepOver;
+		stepOver;
+		stepOver.
+
+	sdbg moveToNode: sdbg methodNode statements first.
+
+	"It is going to execute the comparison a = 2"
+	oldNode := sdbg node.
+	oldContext := sdbg context.
+
+	"We want to enter the block, to get to execute a:=3"
+	aimedNode := sdbg methodNode statements second body statements first
+		             value.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	self assert: aimedPC isNil.
+	self assert: (sdbg temporaryNamed: #a) equals: 0.
+
+	sdbg moveToNode: aimedNode.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 0.
+
+	self assert: sdbg node identicalTo: aimedNode.
+	self assert: sdbg context sender identicalTo: oldContext.
+
+	sdbg
+		stepOver;
+		stepOver.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	sdbg
+		stepOver;
+		stepOver;
+		stepOver.
+	"When you perform a stepOver, you quit the block and continue just after the ifTrue: message"
+	self assert: (sdbg temporaryNamed: #a) equals: 3.
+	self assert: sdbg topStack equals: 42
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInIfTrueIfFalseBlock [
+
+	| oldNode sdbg aimedNode oldContext aimedPC |
+	self skip.
+	sdbg := SindarinDebugger debug: [ self helperMethodWithIfTrueBlock ].
+	sdbg
+		step;
+		stepOver.
+
+	"It is going to execute the comparison a = 2"
+	oldNode := sdbg node.
+	oldContext := sdbg context.
+
+	"We want to enter the block, to get to execute a:=3"
+	aimedNode := sdbg methodNode statements second arguments first body
+		             statements first.
+	aimedPC := sdbg methodNode firstPcForNode: aimedNode.
+
+	self assert: aimedPC isNotNil.
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	sdbg moveToNode: aimedNode.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 1.
+
+	self assert: sdbg node identicalTo: aimedNode.
+	self assert: sdbg pc identicalTo: aimedPC.
+	self assert: sdbg context identicalTo: oldContext.
+
+	sdbg stepOver.
+
+	self assert: (sdbg temporaryNamed: #a) equals: 3.
+
+	sdbg stepOver.
+	"When you perform a stepOver, you quit the block and continue just after the ifTrue: message"
+	self assert: (sdbg temporaryNamed: #a) equals: 4
 ]
 
 { #category : #tests }

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -243,6 +243,13 @@ SindarinDebuggerTest >> helperMethodWithBlockWithNoReturn [
 ]
 
 { #category : #helpers }
+SindarinDebuggerTest >> helperMethodWithDoubleAssignment [
+
+	| b a |
+	a := b :=  1
+]
+
+{ #category : #helpers }
 SindarinDebuggerTest >> helperMethodWithEvaluatedBlock [
 
 	| a b block |
@@ -752,6 +759,28 @@ SindarinDebuggerTest >> testMoveToNodeKeepsSameStateAndPushesCorrectElementsOnSt
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNode [
+
+	| scdbg newPc newNode expectedStackTop |
+	scdbg := SindarinDebugger debug: [ 
+		         self helperMethodWithDoubleAssignment ].
+
+	scdbg
+		step;
+		stepOver.
+	"pc of a := 5"
+	newNode := scdbg methodNode.
+	newPc := scdbg methodNode firstPcForNode: scdbg methodNode.
+	expectedStackTop := scdbg topStack.
+
+	scdbg moveToNode: newNode.
+
+	self assert: scdbg node equals: newNode.
+	self assert: scdbg pc equals: newPc.
+	self assert: scdbg topStack equals: expectedStackTop
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeInMethod [
 
 	| oldNode sdbg aimedNode |
@@ -812,10 +841,10 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableExecutesAssocia
 	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
 	sdbg step.
 	oldNode := sdbg node.
-	"This is the literal value node 5 from `Point x: 5 y: '3' asInteger"
+	"This is the literal variable Point from `Point x: 5 y: '3' asInteger"
 	aimedNode := sdbg methodNode statements last value receiver.
-	indexOfAimedNode := sdbg methodNode allChildren indexOf: aimedNode.
-	siblingsAfterAimedNode := sdbg methodNode allChildren 
+	indexOfAimedNode := sdbg methodNode allChildrenPostOrder identityIndexOf: aimedNode.
+	siblingsAfterAimedNode := sdbg methodNode allChildrenPostOrder
 		                          withIndexSelect: [ :value :index | 
 		                          index > indexOfAimedNode ].
 
@@ -835,6 +864,47 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableExecutesAssocia
 		self assert: (each isVariable or: [ each isLiteralNode ]) ].
 
 	self deny: (realNode isLiteralNode or: [ realNode isVariable ])
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableThatHasNoAssociatedBytecodesMovesToNextNodeThatIsNotLiteralNorVariableThatHasAnAssociatedPC [
+
+	| oldNode sdbg aimedNode siblingsAfterAimedNode indexOfAimedNode realNode indexOfRealNode |
+	sdbg := SindarinDebugger debug: [ 
+		        self helperMethodWithDoubleAssignment ].
+	sdbg step.
+	oldNode := sdbg node.
+	"This is the variable node b from `a:= b:= 1`"
+	aimedNode := sdbg methodNode statements first value variable.
+	indexOfAimedNode := sdbg methodNode allChildrenPostOrder identityIndexOf:
+		                    aimedNode.
+	siblingsAfterAimedNode := sdbg methodNode allChildrenPostOrder 
+		                          withIndexSelect: [ :value :index | 
+		                          index > indexOfAimedNode ].
+
+	self assert: (sdbg methodNode pcsForNode: aimedNode) isEmpty.
+
+	sdbg moveToNode: aimedNode.
+
+	realNode := sdbg node.
+	indexOfRealNode := siblingsAfterAimedNode identityIndexOf: realNode.
+
+	self deny: realNode identicalTo: aimedNode.
+	siblingsAfterAimedNode
+		from: 1
+		to: indexOfRealNode - 1
+		do: [ :each | 
+			self assert: (each isVariable or: [ 
+					 each isLiteralNode or: [ 
+						 (sdbg methodNode pcsForNode: each) isEmpty ] ]) ].
+
+	" Why doesn't it work ??
+	self deny: (realNode isLiteralNode or: [   realNode isVariable or: [   (sdbg methodNode pcsForNode: realNode) isEmpty  ] ]) "
+	
+	self
+		deny: realNode isLiteralNode;
+		deny: realNode isVariable;
+		deny: (sdbg methodNode pcsForNode: realNode) isEmpty
 ]
 
 { #category : #tests }

--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -390,7 +390,7 @@ SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsBeforeInAnyContext [
 ]
 
 { #category : #tests }
-SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnStack [
+SindarinDebuggerTest >> testChangingPcInTheMiddleOfStatementSkipsTheBeginningOfStatement [
 
 	| scdbg newPc newNode expectedStackTop |
 	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
@@ -398,8 +398,42 @@ SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnSt
 	scdbg
 		step;
 		stepOver;
+		stepOver;
 		stepOver.
-	"pc of '3' asInteger"
+	"pc of Point x: y:"
+	newNode := scdbg node.
+	newPc := scdbg pc.
+	expectedStackTop := scdbg topStack.
+
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver.
+	"pc of a := 5"
+	
+	self assert: (scdbg temporaryNamed: #a) equals: 1.
+
+	scdbg pc: newPc.
+	"It should skip the assignment a:=5 AND skip the beginning of the statement ('3' asInteger)"
+
+	self assert: (scdbg temporaryNamed: #a) equals: 1.
+	self assert: scdbg node equals: newNode.
+	self assert: scdbg pc equals: newPc.
+	self deny: scdbg topStack equals: expectedStackTop.
+	self assert: scdbg topStack equals: '3' "topStack is nil because the message send asInteger to the receiver '3' has been skipped"
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnStack [
+
+	| scdbg newPc newNode expectedStackTop |
+	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+
+	scdbg
+		step;
+		stepOver.
+	"pc of a := 5"
 	newNode := scdbg node.
 	newPc := scdbg pc.
 	expectedStackTop := scdbg topStack.
@@ -418,9 +452,33 @@ SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnSt
 ]
 
 { #category : #tests }
+SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsGreaterThanEndPC [
+
+	| oldPC sdbg |
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+	oldPC := sdbg pc.
+	self
+		shouldnt: [ sdbg pc: sdbg method endPC ] raise: NotValidPcError;
+		deny: sdbg pc equals: oldPC.
+	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg
+		step;
+		stepOver;
+		stepOver.
+	oldPC := sdbg pc.
+	self
+		should: [ sdbg pc: sdbg method endPC + 1 ] raise: NotValidPcError;
+		assert: sdbg pc equals: oldPC
+]
+
+{ #category : #tests }
 SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
 
-	| scdbg newPc newNode expectedStackTop |
+	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
 
 	scdbg
@@ -438,11 +496,6 @@ SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
 		stepOver.
 
 	self should: [ scdbg pc: scdbg method initialPC - 1 ] raise: NotValidPcError.
-
-	self assert: (scdbg temporaryNamed: #a) equals: 5.
-	self assert: scdbg node equals: newNode.
-	self assert: scdbg pc equals: newPc.
-	self assert: scdbg topStack equals: expectedStackTop
 ]
 
 { #category : #tests }

--- a/Sindarin/DebugSession.extension.st
+++ b/Sindarin/DebugSession.extension.st
@@ -4,3 +4,9 @@ Extension { #name : #DebugSession }
 DebugSession >> asSindarinDebugSession [
 	^ SindarinDebugSession new debugSession: self
 ]
+
+{ #category : #'*Sindarin' }
+DebugSession >> suspendedContext: aContext [ 
+	
+	interruptedContext := aContext
+]

--- a/Sindarin/NodeNotInASTError.class.st
+++ b/Sindarin/NodeNotInASTError.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #NodeNotInASTError,
+	#superclass : #Error,
+	#category : #'Sindarin-Exceptions'
+}

--- a/Sindarin/NodeNotInASTError.class.st
+++ b/Sindarin/NodeNotInASTError.class.st
@@ -1,3 +1,6 @@
+"
+I am signaled when we try to move the execution to a node that is not in the home context's method ast.
+"
 Class {
 	#name : #NodeNotInASTError,
 	#superclass : #Error,

--- a/Sindarin/NotValidPcError.class.st
+++ b/Sindarin/NotValidPcError.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #NotValidPcError,
+	#superclass : #Error,
+	#category : #'Sindarin-Exceptions'
+}

--- a/Sindarin/NotValidPcError.class.st
+++ b/Sindarin/NotValidPcError.class.st
@@ -1,3 +1,6 @@
+"
+I am signaled when I try to modify the execution of a context to get to an invalid PC (lower than the method initalPC or greater than the method endPC)
+"
 Class {
 	#name : #NotValidPcError,
 	#superclass : #Error,

--- a/Sindarin/OCBytecodeToASTCache.extension.st
+++ b/Sindarin/OCBytecodeToASTCache.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #OCBytecodeToASTCache }
+
+{ #category : #'*Sindarin' }
+OCBytecodeToASTCache >> firstRecursiveBcOffsetForStatementNode: aStatementNode [
+
+	^ self methodOrBlockNode bcToASTCache bcToASTMap keys sorted detect: [ 
+		  :key | (self nodeForPC: key) statementNode == aStatementNode ]
+]

--- a/Sindarin/RBBlockNode.extension.st
+++ b/Sindarin/RBBlockNode.extension.st
@@ -40,6 +40,7 @@ RBBlockNode >> parentOfIdenticalSubtree: subtree [
 		  ifNone: [ nil ]
 ]
 
+{ #category : #'*Sindarin' }
 RBBlockNode >> skipWithDebugger: aSindarinDebugger [
 
 	aSindarinDebugger skipBlockNode 

--- a/Sindarin/RBBlockNode.extension.st
+++ b/Sindarin/RBBlockNode.extension.st
@@ -38,6 +38,7 @@ RBBlockNode >> parentOfIdenticalSubtree: subtree [
 		  detect: [ :e | e == subtree ]
 		  ifFound: [ :e | e parent ]
 		  ifNone: [ nil ]
+]
 
 RBBlockNode >> skipWithDebugger: aSindarinDebugger [
 

--- a/Sindarin/RBBlockNode.extension.st
+++ b/Sindarin/RBBlockNode.extension.st
@@ -1,6 +1,37 @@
 Extension { #name : #RBBlockNode }
 
 { #category : #'*Sindarin' }
+RBBlockNode >> executedNodesAfter: aNode [
+
+	"Gives all nodes that are executed after aNode. Assuming that aNode is a recursive child, then all nodes executed after it are all nodes after it in allChildrenPostOrder"
+
+	| nodesAfter indexOfNode |
+	nodesAfter := self allChildrenPostOrder.
+	indexOfNode := nodesAfter identityIndexOf: aNode.
+	nodesAfter := nodesAfter withIndexSelect: [ :value :index | 
+		              index > indexOfNode ].
+	^ nodesAfter
+]
+
+{ #category : #'*Sindarin' }
+RBBlockNode >> firstPCOfStatement: aStatementNode [
+
+	^ self bcToASTCache firstRecursiveBcOffsetForStatementNode: aStatementNode
+]
+
+{ #category : #'*Sindarin' }
+RBBlockNode >> nextExecutedNodeAfter: aNode [
+
+	"Find first node that is after aNode that has an associated pc in method node all children (post-order)"
+
+	| indexOfNextNode nodesAfter |
+	nodesAfter := self executedNodesAfter: aNode.
+	indexOfNextNode := nodesAfter findFirst: [ :each | 
+		                   (self firstPcForNode: each) isNotNil ].
+	^ nodesAfter at: indexOfNextNode
+]
+
+{ #category : #'*Sindarin' }
 RBBlockNode >> parentOfIdenticalSubtree: subtree [
 
 	^ self allChildren reversed

--- a/Sindarin/RBBlockNode.extension.st
+++ b/Sindarin/RBBlockNode.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #RBBlockNode }
+
+{ #category : #'*Sindarin' }
+RBBlockNode >> parentOfIdenticalSubtree: subtree [
+
+	^ self allChildren reversed
+		  detect: [ :e | e == subtree ]
+		  ifFound: [ :e | e parent ]
+		  ifNone: [ nil ]
+]

--- a/Sindarin/RBMethodNode.extension.st
+++ b/Sindarin/RBMethodNode.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #RBMethodNode }
+
+{ #category : #'*Sindarin' }
+RBMethodNode >> parentOfIdenticalSubtree: subtree [
+
+	^ self allChildren reversed
+		  detect: [ :e | e == subtree ]
+		  ifFound: [ :e | e parent ]
+		  ifNone: [ nil ]
+]

--- a/Sindarin/RBMethodNode.extension.st
+++ b/Sindarin/RBMethodNode.extension.st
@@ -1,18 +1,34 @@
 Extension { #name : #RBMethodNode }
 
 { #category : #'*Sindarin' }
+RBMethodNode >> executedNodesAfter: aNode [
+
+	"Gives all nodes that are executed after aNode. Assuming that aNode is a recursive child, then all nodes executed after it are all nodes after it in allChildrenPostOrder"
+
+	| nodesAfter indexOfNode |
+	nodesAfter := self allChildrenPostOrder.
+	indexOfNode := nodesAfter identityIndexOf: aNode.
+	nodesAfter := nodesAfter withIndexSelect: [ :value :index | 
+		              index > indexOfNode ].
+	^ nodesAfter
+]
+
+{ #category : #'*Sindarin' }
 RBMethodNode >> firstPCOfStatement: aStatementNode [
 
-	| indexOfStatementNode statementBefore lastPcInStatementBefore |
-	indexOfStatementNode := self statements identityIndexOf:
-		                        aStatementNode.
-	indexOfStatementNode == 1 ifTrue: [ 
-		^ self bcToASTCache bcToASTMap keys sorted detect: [ :key | 
-			  (self sourceNodeForPC: key) statementNode == aStatementNode ] ].
-	statementBefore := self statements at: indexOfStatementNode - 1.
-	lastPcInStatementBefore := self lastPcForNode: statementBefore.
-	^ self bcToASTCache bcToASTMap keys sorted detect: [ :key | 
-		  key > lastPcInStatementBefore ]
+	^ self bcToASTCache firstRecursiveBcOffsetForStatementNode: aStatementNode
+]
+
+{ #category : #'*Sindarin' }
+RBMethodNode >> nextExecutedNodeAfter: aNode [
+
+	"Find first node that is after aNode that has an associated pc in method node all children (post-order)"
+
+	| indexOfNextNode nodesAfter |
+	nodesAfter := self executedNodesAfter: aNode.
+	indexOfNextNode := nodesAfter findFirst: [ :each | 
+		                   (self firstPcForNode: each) isNotNil ].
+	^ nodesAfter at: indexOfNextNode
 ]
 
 { #category : #'*Sindarin' }

--- a/Sindarin/RBMethodNode.extension.st
+++ b/Sindarin/RBMethodNode.extension.st
@@ -6,7 +6,9 @@ RBMethodNode >> firstPCOfStatement: aStatementNode [
 	| indexOfStatementNode statementBefore lastPcInStatementBefore |
 	indexOfStatementNode := self statements identityIndexOf:
 		                        aStatementNode.
-	indexOfStatementNode == 1 ifTrue: [ ^ self compiledMethod initialPC ].
+	indexOfStatementNode == 1 ifTrue: [ 
+		^ self bcToASTCache bcToASTMap keys sorted detect: [ :key | 
+			  (self sourceNodeForPC: key) statementNode == aStatementNode ] ].
 	statementBefore := self statements at: indexOfStatementNode - 1.
 	lastPcInStatementBefore := self lastPcForNode: statementBefore.
 	^ self bcToASTCache bcToASTMap keys sorted detect: [ :key | 

--- a/Sindarin/RBMethodNode.extension.st
+++ b/Sindarin/RBMethodNode.extension.st
@@ -1,6 +1,19 @@
 Extension { #name : #RBMethodNode }
 
 { #category : #'*Sindarin' }
+RBMethodNode >> firstPCOfStatement: aStatementNode [
+
+	| indexOfStatementNode statementBefore lastPcInStatementBefore |
+	indexOfStatementNode := self statements identityIndexOf:
+		                        aStatementNode.
+	indexOfStatementNode == 1 ifTrue: [ ^ self compiledMethod initialPC ].
+	statementBefore := self statements at: indexOfStatementNode - 1.
+	lastPcInStatementBefore := self lastPcForNode: statementBefore.
+	^ self bcToASTCache bcToASTMap keys sorted detect: [ :key | 
+		  key > lastPcInStatementBefore ]
+]
+
+{ #category : #'*Sindarin' }
 RBMethodNode >> parentOfIdenticalSubtree: subtree [
 
 	^ self allChildren reversed

--- a/Sindarin/RBMethodNode.extension.st
+++ b/Sindarin/RBMethodNode.extension.st
@@ -8,3 +8,19 @@ RBMethodNode >> parentOfIdenticalSubtree: subtree [
 		  ifFound: [ :e | e parent ]
 		  ifNone: [ nil ]
 ]
+
+{ #category : #'*Sindarin' }
+RBMethodNode >> statementNodeContaining: aNode [
+
+	| statementNode parentOfStatementNode |
+	statementNode := aNode.
+	parentOfStatementNode := self parentOfIdenticalSubtree:
+		                         statementNode.
+	parentOfStatementNode
+		ifNil: [ ^ NodeNotInASTError signal ]
+		ifNotNil: [ 
+			[ parentOfStatementNode isSequence ] whileFalse: [ 
+				statementNode := parentOfStatementNode.
+				parentOfStatementNode := parentOfStatementNode parent ] ].
+	^ statementNode
+]

--- a/Sindarin/RBProgramNode.extension.st
+++ b/Sindarin/RBProgramNode.extension.st
@@ -11,6 +11,7 @@ RBProgramNode >> allChildrenPostOrder [
 	^ children
 ]
 
+{ #category : #'*Sindarin' }
 RBProgramNode >> skipWithDebugger: aSindarinDebugger [
 
 	aSindarinDebugger step

--- a/Sindarin/RBProgramNode.extension.st
+++ b/Sindarin/RBProgramNode.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #RBProgramNode }
+
+{ #category : #'*Sindarin' }
+RBProgramNode >> allChildrenPostOrder [
+
+	| children |
+	children := OrderedCollection new.
+	self children do: [ :each | 
+		each allChildrenPostOrder do: [ :child | children addLast: child ] ].
+	children addLast: self.
+	^ children
+]

--- a/Sindarin/RBProgramNode.extension.st
+++ b/Sindarin/RBProgramNode.extension.st
@@ -9,6 +9,7 @@ RBProgramNode >> allChildrenPostOrder [
 		each allChildrenPostOrder do: [ :child | children addLast: child ] ].
 	children addLast: self.
 	^ children
+]
 
 RBProgramNode >> skipWithDebugger: aSindarinDebugger [
 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -402,7 +402,20 @@ SindarinDebugger >> moveToNode: aNode [
 			ifNil: [ 
 				(aNode == self methodNode or: [ aNode == self methodNode body ])
 					ifTrue: [ firstPCForNode := self method endPC ]
-					ifFalse: [ ^ NodeNotInASTError signal ] ]
+					ifFalse: [ 
+						self context ~~ self context home
+							ifTrue: [ 
+								| oldContext |
+								oldContext := self context.
+								self currentProcess suspendedContext: oldContext home.
+								self debugSession suspendedContext: oldContext home.
+								[ self moveToNode: aNode ]
+									on: NodeNotInASTError
+									do: [ 
+										self currentProcess suspendedContext: oldContext.
+										self debugSession suspendedContext: oldContext ].
+								^ self ]
+							ifFalse: [ ^ NodeNotInASTError signal ] ] ]
 			ifNotNil: [ :parent | 
 				| nodesAfter indexOfNode indexOfNextNode nextNode |
 				"aNode statementNode parent parent isBlock ifTrue: [ 
@@ -426,21 +439,19 @@ SindarinDebugger >> moveToNode: aNode [
 				firstPCForNode := self methodNode firstPcForNode: nextNode.
 				nextNode isBlock ifTrue: [ 
 					| newContext blockClosure olderPC |
-					"olderPC := self pc."
-					
-					"We move to the block node pc to get its full block closure"
+					"olderPC := self pc.""We move to the block node pc to get its full block closure"
 					self pc: firstPCForNode.
 					self stepBytecode.
 					"The array of temps is missing on the stack. The last  bytecode of the previous statement pushes it."
 					blockClosure := self context top.
 					newContext := blockClosure asContextWithSender: self context.
 					"self pc: olderPC."
-					
+
 					"we need to change the suspended context and maybe do the same in its debug session"
 					self currentProcess suspendedContext: newContext.
 					self debugSession suspendedContext: newContext.
 					"This does an infinite loop because it doesn't actually change the interrupted context in the debug session"
-					^  self moveToNode: aNode ] ] ].
+					^ self moveToNode: aNode ] ] ].
 
 	self pc: firstPCForNode
 ]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -398,8 +398,20 @@ SindarinDebugger >> moveToNode: aNode [
 	firstPCForNode := self methodNode firstPcForNode: aNode.
 
 	firstPCForNode ifNil: [ 
-		(self methodNode parentOfIdenticalSubtree: aNode) ifNil: [ 
-			^ NodeNotInASTError signal ] ].
+		(self methodNode parentOfIdenticalSubtree: aNode)
+			ifNil: [ ^ NodeNotInASTError signal ]
+			ifNotNil: [ :parent | 
+				| nodesAfter indexOfNode indexOfNextNode nextNode |
+				nodesAfter := self methodNode allChildrenPostOrder.
+				indexOfNode := nodesAfter identityIndexOf: aNode.
+				nodesAfter := nodesAfter withIndexSelect: [ :value :index | 
+					              index > indexOfNode ].
+				"if aimed node has no associated pc, we find the first node executed after him (in pre-order) that has at least one associated pc"
+				indexOfNextNode := nodesAfter findFirst: [ :each | 
+					                   (self methodNode firstPcForNode: each)
+						                   isNotNil ].
+				nextNode := nodesAfter at: indexOfNextNode.
+				firstPCForNode := self methodNode firstPcForNode: nextNode ] ].
 
 	self pc: firstPCForNode
 ]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -453,21 +453,24 @@ SindarinDebugger >> pc [
 { #category : #accessing }
 SindarinDebugger >> pc: anInteger [
 
-	| statementNodeContainingNextNode nextNode firstExecutedNodeInStatement methodNode firstPCOfStatementNode |
+	| statementNodeContainingNextNode nextNode methodNode firstPCOfStatementNode |
 	(anInteger < self method initialPC or: [ 
 		 anInteger > self method endPC ]) ifTrue: [ 
 		^ NotValidPcError signal ].
 	methodNode := self methodNode.
 	nextNode := methodNode sourceNodeForPC: anInteger.
-	statementNodeContainingNextNode := self statementNodeContaining:
-		                                   nextNode.
-	firstPCOfStatementNode := self firstPCOfStatement:
-		                          statementNodeContainingNextNode.
-	firstExecutedNodeInStatement := methodNode sourceNodeForPC:
-		                                firstPCOfStatementNode.
-	[ self context stackPtr > self context numTemps ] whileTrue: [ 
-		self context pop ].
-	self context pc: self method initialPC.
+	(nextNode == methodNode or: [ nextNode == methodNode body ])
+		ifTrue: [ firstPCOfStatementNode := anInteger ]
+		ifFalse: [ 
+			statementNodeContainingNextNode := self statementNodeContaining:
+				                                   nextNode.
+			firstPCOfStatementNode := self firstPCOfStatement:
+				                          statementNodeContainingNextNode.
+			"firstExecutedNodeInStatement := methodNode sourceNodeForPC:
+		                                firstPCOfStatementNode."
+			[ self context stackPtr > self context numTemps ] whileTrue: [ 
+				self context pop ] ].
+	self context pc: firstPCOfStatementNode.
 	self debugSession stepToFirstInterestingBytecodeIn:
 		self debugSession interruptedProcess.
 	self skipUpToNode: nextNode

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -399,7 +399,10 @@ SindarinDebugger >> moveToNode: aNode [
 
 	firstPCForNode ifNil: [ 
 		(self methodNode parentOfIdenticalSubtree: aNode)
-			ifNil: [ ^ NodeNotInASTError signal ]
+			ifNil: [ 
+				(aNode == self methodNode or: [ aNode == self methodNode body ])
+					ifTrue: [ firstPCForNode := self method endPC ]
+					ifFalse: [ ^ NodeNotInASTError signal ] ]
 			ifNotNil: [ :parent | 
 				| nodesAfter indexOfNode indexOfNextNode nextNode |
 				nodesAfter := self methodNode allChildrenPostOrder.

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -140,6 +140,13 @@ SindarinDebugger >> canStillExecute: aProgramNode [
 	^ rightContext pc < lastPcForNode
 ]
 
+{ #category : #cleaning }
+SindarinDebugger >> cleanStack [
+
+	[ self context stackPtr > self context numTemps ] whileTrue: [ 
+		self context pop ]
+]
+
 { #category : #stackAccess }
 SindarinDebugger >> context [
 	"Returns a reification of the current stack-frame."
@@ -297,6 +304,25 @@ SindarinDebugger >> isExecutionFinished [
 	^ process isTerminated
 ]
 
+{ #category : #'API - changes' }
+SindarinDebugger >> jumpIntoBlock: aBlockNode toNode: targetNode [
+
+	"Moves to targetNode that must be in aBlockNode, which should be a recursive child"
+
+	| blockClosure newContext firstPCForNode |
+	"To jump into a block, we change pc to the block creation pc and we step it to get the block closure and create a new context for it. Then, we call moveToNode: recursively to go to the correct pc in the new context (or to create even more contexts if we want to enter embedded blocks)"
+	firstPCForNode := self methodNode firstPcForNode: aBlockNode.
+	self pc: firstPCForNode.
+	self stepBytecode.
+	blockClosure := self context top.
+	newContext := blockClosure asContextWithSender: self context.
+
+	"we need to change the suspended context and do the same in its debug session to see what we do in the debugger"
+	self currentProcess suspendedContext: newContext.
+	self debugSession suspendedContext: newContext.
+	^ self moveToNode: targetNode
+]
+
 { #category : #stackAccessHelpers }
 SindarinDebugger >> message: aSelector [
 	"Returns whether the execution is about to send a message of selector @aSelector to any object"
@@ -394,64 +420,27 @@ SindarinDebugger >> methodNode [
 { #category : #'API - changes' }
 SindarinDebugger >> moveToNode: aNode [
 
+	"Allows to jump to the first bytecode offset associated to aNode, as long as aNode is in the same lexical context as the suspended context"
+
 	| firstPCForNode |
 	firstPCForNode := self methodNode firstPcForNode: aNode.
 
-	firstPCForNode ifNil: [ "]"
+	firstPCForNode ifNil: [ "If a node does not have any associated pc and if it is not a child in the method node then, aNode may be identical to the method node or its body, in which case, we move to the endPC. Otherwise, we check if it is a child in the home context's method node. If this is the case, this means we want to exit a block context. Otherwise, aNode is not a child in the home context's method node"
 		(self methodNode parentOfIdenticalSubtree: aNode)
 			ifNil: [ 
 				(aNode == self methodNode or: [ aNode == self methodNode body ])
 					ifTrue: [ firstPCForNode := self method endPC ]
 					ifFalse: [ 
 						self context ~~ self context home
-							ifTrue: [ 
-								| oldContext |
-								oldContext := self context.
-								self currentProcess suspendedContext: oldContext home.
-								self debugSession suspendedContext: oldContext home.
-								[ self moveToNode: aNode ]
-									on: NodeNotInASTError
-									do: [ 
-										self currentProcess suspendedContext: oldContext.
-										self debugSession suspendedContext: oldContext ].
-								^ self ]
+							ifTrue: [ ^ self tryMoveToNodeInHomeContext: aNode ]
 							ifFalse: [ ^ NodeNotInASTError signal ] ] ]
 			ifNotNil: [ :parent | 
-				| nodesAfter indexOfNode indexOfNextNode nextNode |
-				"aNode statementNode parent parent isBlock ifTrue: [ 
-					| newContext blockClosure |
-					blockClosure := aNode statementNode parent parent evaluate.
-					newContext := blockClosure asContextWithSender: self context.
-					""we need to change the suspended context and maybe do the same in its debug session""
-					self currentProcess suspendedContext: newContext.
-					self debugSession
-						process: self currentProcess
-						context: newContext ].""ifFalse: [ "
-				nodesAfter := self methodNode allChildrenPostOrder.
-				indexOfNode := nodesAfter identityIndexOf: aNode.
-				nodesAfter := nodesAfter withIndexSelect: [ :value :index | 
-					              index > indexOfNode ].
-				"if aimed node has no associated pc, we find the first node executed after him (in pre-order) that has at least one associated pc"
-				indexOfNextNode := nodesAfter findFirst: [ :each | 
-					                   (self methodNode firstPcForNode: each)
-						                   isNotNil ].
-				nextNode := nodesAfter at: indexOfNextNode.
+				| nextNode |
+				"If a node does not have any associated pc but this node is a child in the method node then, we go to the next node that will be executed (so in pre-order) and that has an associated pc in this context."
+				nextNode := self nextExecutedNodeAfter: aNode.
 				firstPCForNode := self methodNode firstPcForNode: nextNode.
-				nextNode isBlock ifTrue: [ 
-					| newContext blockClosure olderPC |
-					"olderPC := self pc.""We move to the block node pc to get its full block closure"
-					self pc: firstPCForNode.
-					self stepBytecode.
-					"The array of temps is missing on the stack. The last  bytecode of the previous statement pushes it."
-					blockClosure := self context top.
-					newContext := blockClosure asContextWithSender: self context.
-					"self pc: olderPC."
-
-					"we need to change the suspended context and maybe do the same in its debug session"
-					self currentProcess suspendedContext: newContext.
-					self debugSession suspendedContext: newContext.
-					"This does an infinite loop because it doesn't actually change the interrupted context in the debug session"
-					^ self moveToNode: aNode ] ] ].
+				nextNode isBlock ifTrue: [ "If the node after aNode is a block node, then this means we want to enter a block." 
+					^ self jumpIntoBlock: nextNode toNode: aNode ] ] ].
 
 	self pc: firstPCForNode
 ]
@@ -461,6 +450,12 @@ SindarinDebugger >> nextBytecode [
 
 	^ self currentBytecode detect: [ :each | 
 		  each offset = self context pc ]
+]
+
+{ #category : #'API - changes' }
+SindarinDebugger >> nextExecutedNodeAfter: aNode [
+
+	^ self methodNode nextExecutedNodeAfter: aNode
 ]
 
 { #category : #astAndAstMapping }
@@ -505,32 +500,22 @@ SindarinDebugger >> pc [
 { #category : #accessing }
 SindarinDebugger >> pc: anInteger [
 
-	| statementNodeContainingNextNode nextNode methodNode firstPCOfStatementNode |
+	"Allows to move to the first PC associated to the node to which anInteger is associated. anInteger must be a valid pc in the suspended context"
+
+	| nextNode methodNode firstPCOfStatementNode |
+	"If aimedPC is outside the context PCs range, then an error is signaled"
 	(anInteger < self method initialPC or: [ 
 		 anInteger > self method endPC ]) ifTrue: [ 
 		^ NotValidPcError signal ].
 	methodNode := self methodNode.
 	nextNode := methodNode sourceNodeForPC: anInteger.
+	"If the aimed node is associated to the method node or its body, then we suppose that it is wanted and we'll get there directly"
 	(nextNode == methodNode or: [ nextNode == methodNode body ])
 		ifTrue: [ firstPCOfStatementNode := anInteger ]
-		ifFalse: [ "statementNodeContainingNextNode := self statementNodeContaining:
-				                                   nextNode.
-			[ statementNodeContainingNextNode parent == self methodNode body ] 
-				whileFalse: [ 
-					statementNodeContainingNextNode := self statementNodeContaining:
-						                                   statementNodeContainingNextNode
-							                                   parent ].
+		ifFalse: [ "If not, we skip to the wanted node, from the first (recursive) pc of the first statement node. We don't skip from the method node initial pc, otherwise we would create again the temp variables and lose their values."
 			firstPCOfStatementNode := self firstPCOfStatement:
-				                          statementNodeContainingNextNode."
-			firstPCOfStatementNode := methodNode bcToASTCache bcToASTMap keys
-				                          sorted detect: [ :key | 
-				                          (methodNode sourceNodeForPC: key)
-					                          statementNode
-				                          == methodNode statements first ].
-			"firstExecutedNodeInStatement := methodNode sourceNodeForPC:
-		                                firstPCOfStatementNode."
-			[ self context stackPtr > self context numTemps ] whileTrue: [ 
-				self context pop ] ].
+				                          methodNode statements first.
+			self cleanStack ].
 	self context pc: firstPCOfStatementNode.
 	self debugSession stepToFirstInterestingBytecodeIn:
 		self debugSession interruptedProcess.
@@ -973,4 +958,21 @@ SindarinDebugger >> terminate [
 { #category : #stackAccessHelpers }
 SindarinDebugger >> topStack [
 	^self context top
+]
+
+{ #category : #'API - changes' }
+SindarinDebugger >> tryMoveToNodeInHomeContext: aNode [
+
+	"Moves to node aNode if aNode is in the lexical context. Otherwise, the program state goes back to how it was before trying and signals an error as the node is not in AST"
+
+	| oldContext |
+	oldContext := self context.
+	self currentProcess suspendedContext: oldContext home.
+	self debugSession suspendedContext: oldContext home.
+	[ self moveToNode: aNode ]
+		on: NodeNotInASTError
+		do: [ 
+			self currentProcess suspendedContext: oldContext.
+			self debugSession suspendedContext: oldContext.
+			^ NodeNotInASTError signal ]
 ]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -714,6 +714,23 @@ SindarinDebugger >> stack [
 	^ self debugSession stack
 ]
 
+{ #category : #API }
+SindarinDebugger >> statementNodeContaining: aNode [
+
+	| method statementNode parentOfStatementNode |
+	method := self methodNode.
+	statementNode := aNode.
+	parentOfStatementNode := method parentOfIdenticalSubtree:
+		                         statementNode.
+	parentOfStatementNode
+		ifNil: [ ^ NodeNotInASTError signal ]
+		ifNotNil: [ 
+			[ parentOfStatementNode isSequence ] whileFalse: [ 
+				statementNode := parentOfStatementNode.
+				parentOfStatementNode := parentOfStatementNode parent ] ].
+	^ statementNode
+]
+
 { #category : #'stepping - steps' }
 SindarinDebugger >> step [
 	"Executes the next instruction. If the instruction is a message-send, step inside it."

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -426,14 +426,16 @@ SindarinDebugger >> moveToNode: aNode [
 				firstPCForNode := self methodNode firstPcForNode: nextNode.
 				nextNode isBlock ifTrue: [ 
 					| newContext blockClosure olderPC |
-					olderPC := self pc.
+					"olderPC := self pc."
+					
 					"We move to the block node pc to get its full block closure"
 					self pc: firstPCForNode.
 					self stepBytecode.
 					"The array of temps is missing on the stack. The last  bytecode of the previous statement pushes it."
-					blockClosure := self context pop.
+					blockClosure := self context top.
 					newContext := blockClosure asContextWithSender: self context.
-					self pc: olderPC.
+					"self pc: olderPC."
+					
 					"we need to change the suspended context and maybe do the same in its debug session"
 					self currentProcess suspendedContext: newContext.
 					self debugSession suspendedContext: newContext.

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -436,7 +436,7 @@ SindarinDebugger >> moveToNode: aNode [
 					self pc: olderPC.
 					"we need to change the suspended context and maybe do the same in its debug session"
 					self currentProcess suspendedContext: newContext.
-					self debugSession process: self currentProcess context: newContext.
+					self debugSession suspendedContext: newContext.
 					"This does an infinite loop because it doesn't actually change the interrupted context in the debug session"
 					^  self moveToNode: aNode ] ] ].
 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -391,6 +391,19 @@ SindarinDebugger >> methodNode [
 	^ self method ast
 ]
 
+{ #category : #'API - changes' }
+SindarinDebugger >> moveToNode: aNode [
+
+	| firstPCForNode |
+	firstPCForNode := self methodNode firstPcForNode: aNode.
+
+	firstPCForNode ifNil: [ 
+		(self methodNode parentOfIdenticalSubtree: aNode) ifNil: [ 
+			^ NodeNotInASTError signal ] ].
+
+	self pc: firstPCForNode
+]
+
 { #category : #'accessing - bytes' }
 SindarinDebugger >> nextBytecode [
 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -397,7 +397,7 @@ SindarinDebugger >> moveToNode: aNode [
 	| firstPCForNode |
 	firstPCForNode := self methodNode firstPcForNode: aNode.
 
-	firstPCForNode ifNil: [ 
+	firstPCForNode ifNil: [ "]"
 		(self methodNode parentOfIdenticalSubtree: aNode)
 			ifNil: [ 
 				(aNode == self methodNode or: [ aNode == self methodNode body ])
@@ -405,6 +405,15 @@ SindarinDebugger >> moveToNode: aNode [
 					ifFalse: [ ^ NodeNotInASTError signal ] ]
 			ifNotNil: [ :parent | 
 				| nodesAfter indexOfNode indexOfNextNode nextNode |
+				"aNode statementNode parent parent isBlock ifTrue: [ 
+					| newContext blockClosure |
+					blockClosure := aNode statementNode parent parent evaluate.
+					newContext := blockClosure asContextWithSender: self context.
+					""we need to change the suspended context and maybe do the same in its debug session""
+					self currentProcess suspendedContext: newContext.
+					self debugSession
+						process: self currentProcess
+						context: newContext ].""ifFalse: [ "
 				nodesAfter := self methodNode allChildrenPostOrder.
 				indexOfNode := nodesAfter identityIndexOf: aNode.
 				nodesAfter := nodesAfter withIndexSelect: [ :value :index | 
@@ -414,7 +423,22 @@ SindarinDebugger >> moveToNode: aNode [
 					                   (self methodNode firstPcForNode: each)
 						                   isNotNil ].
 				nextNode := nodesAfter at: indexOfNextNode.
-				firstPCForNode := self methodNode firstPcForNode: nextNode ] ].
+				firstPCForNode := self methodNode firstPcForNode: nextNode.
+				nextNode isBlock ifTrue: [ 
+					| newContext blockClosure olderPC |
+					olderPC := self pc.
+					"We move to the block node pc to get its full block closure"
+					self pc: firstPCForNode.
+					self stepBytecode.
+					"The array of temps is missing on the stack. The last  bytecode of the previous statement pushes it."
+					blockClosure := self context pop.
+					newContext := blockClosure asContextWithSender: self context.
+					self pc: olderPC.
+					"we need to change the suspended context and maybe do the same in its debug session"
+					self currentProcess suspendedContext: newContext.
+					self debugSession process: self currentProcess context: newContext.
+					"This does an infinite loop because it doesn't actually change the interrupted context in the debug session"
+					^  self moveToNode: aNode ] ] ].
 
 	self pc: firstPCForNode
 ]
@@ -476,11 +500,20 @@ SindarinDebugger >> pc: anInteger [
 	nextNode := methodNode sourceNodeForPC: anInteger.
 	(nextNode == methodNode or: [ nextNode == methodNode body ])
 		ifTrue: [ firstPCOfStatementNode := anInteger ]
-		ifFalse: [ 
-			statementNodeContainingNextNode := self statementNodeContaining:
+		ifFalse: [ "statementNodeContainingNextNode := self statementNodeContaining:
 				                                   nextNode.
+			[ statementNodeContainingNextNode parent == self methodNode body ] 
+				whileFalse: [ 
+					statementNodeContainingNextNode := self statementNodeContaining:
+						                                   statementNodeContainingNextNode
+							                                   parent ].
 			firstPCOfStatementNode := self firstPCOfStatement:
-				                          statementNodeContainingNextNode.
+				                          statementNodeContainingNextNode."
+			firstPCOfStatementNode := methodNode bcToASTCache bcToASTMap keys
+				                          sorted detect: [ :key | 
+				                          (methodNode sourceNodeForPC: key)
+					                          statementNode
+				                          == methodNode statements first ].
 			"firstExecutedNodeInStatement := methodNode sourceNodeForPC:
 		                                firstPCOfStatementNode."
 			[ self context stackPtr > self context numTemps ] whileTrue: [ 

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -242,6 +242,12 @@ SindarinDebugger >> debugSession [
 	^ sindarinSession debugSession
 ]
 
+{ #category : #accessing }
+SindarinDebugger >> firstPCOfStatement: aStatementNode [
+
+	^ self methodNode firstPCOfStatement: aStatementNode
+]
+
 { #category : #private }
 SindarinDebugger >> hasSignalledUnhandledException [
 	"Returns true if the debugged execution has signalled an exception that has not been handled by any on:do: (i.e. the #defaultAction of the exception is about to be executed. This default action typically leads to opening a debugger on the process that signalled the exception)"
@@ -434,12 +440,24 @@ SindarinDebugger >> pc [
 { #category : #accessing }
 SindarinDebugger >> pc: anInteger [
 
-	self context pc: anInteger.
+	| statementNodeContainingNextNode nextNode firstExecutedNodeInStatement methodNode firstPCOfStatementNode |
+	(anInteger < self method initialPC or: [ 
+		 anInteger > self method endPC ]) ifTrue: [ 
+		^ NotValidPcError signal ].
+	methodNode := self methodNode.
+	nextNode := methodNode sourceNodeForPC: anInteger.
+	statementNodeContainingNextNode := self statementNodeContaining:
+		                                   nextNode.
+	firstPCOfStatementNode := self firstPCOfStatement:
+		                          statementNodeContainingNextNode.
+	firstExecutedNodeInStatement := methodNode sourceNodeForPC:
+		                                firstPCOfStatementNode.
 	[ self context stackPtr > self context numTemps ] whileTrue: [ 
 		self context pop ].
-
+	self context pc: self method initialPC.
 	self debugSession stepToFirstInterestingBytecodeIn:
-		self debugSession interruptedProcess
+		self debugSession interruptedProcess.
+	self skipUpToNode: nextNode
 ]
 
 { #category : #'stepping -  auto' }


### PR DESCRIPTION
Fixes #30.

Needs #53  and  #54  to be merged first.

This PR introduces a new JumpToCaret command that allows to move the program execution to the first PC associated to the specific AST node associated to where the caret has been placed.

The command itself can be accessed via the advanced steps menu in the debugger toolbar:

![image](https://user-images.githubusercontent.com/97704417/199499862-1f6286e9-1641-4673-89ec-0eb710bfea99.png)

You should put your caret somewhere in the code before using this command, otherwise it will go back to the beginning of the method (even before the creation of temporaries).

Tutorial: What you can do with JumpToCaret

- Everything that you can do with SkipUpTo:
  
* Jump to caret forward to skip instructions to caret:

In the screnshot below, `a`  is equal to 1 and we jump to caret that is on the `a * 42` message node:

![image](https://user-images.githubusercontent.com/97704417/199500697-33ec53cd-82e4-4fd3-aba0-2bc4698dc2e2.png)

After jumping to caret, the next instruction that will be executed is the `a * 42` message node. You can also see that `a` is still equal to 1 as the assignment `a := a +2` has been skipped:

![image](https://user-images.githubusercontent.com/97704417/199501275-aa064c79-25e4-43cf-a711-e3587beb0bad.png)

* Jump to caret inside an inlined block (such as an ifTrue: or ifFalse: block)

In the screenshot below, we put our caret inside the ifFalse: block:

![image](https://user-images.githubusercontent.com/97704417/199502028-cb430763-59ed-4a17-a0bf-5a0c81569a62.png)

After jumping to caret, we have entered the ifFalse: block and `a` is still nil, as the assignment `a := true` has been skipped.

![image](https://user-images.githubusercontent.com/97704417/199502784-3acfaea0-95d2-46cd-b9aa-3ff70b1a9795.png)

Then, you can enter the ifTrue: block if you want too: 

![image](https://user-images.githubusercontent.com/97704417/199502718-ad73304a-0115-49cc-9fb7-f1c159401c3b.png)

![image](https://user-images.githubusercontent.com/97704417/199502875-7a47809f-92a5-43e9-9619-532bb6fff8b6.png)

- You can also do other things that you cannot do with the SkipUpTo command:

* JumpToCaret allows to go backward in the execution, while keeping the state of the program before jumping to caret.

In this screenshot below, `a` is equal to 1, and we want to jump to caret on the message node `a + 2`:

![image](https://user-images.githubusercontent.com/97704417/199504092-b114a516-e84f-42ea-b484-523f15475353.png)

After jumping to caret, as you'd expect, the next instruction that will be executed is the message node: 

![image](https://user-images.githubusercontent.com/97704417/199504431-8ac8c26d-3520-4bb8-8343-c3024d6e832e.png)

If you step twice, the message node `a + 2` and the assignment node `a := a +2` will be executed and `a` will be equal to 3:

![image](https://user-images.githubusercontent.com/97704417/199505116-2deb0072-bd31-48d4-b7c5-e48fa3aa05f5.png)

Now, what you can do with jumpToCaret and that you can't do with skipUpTo is jumping back to caret on the `a + 2` message node:

![image](https://user-images.githubusercontent.com/97704417/199505241-d2cdc77d-13c9-4cb7-a8b1-aa3f7d5c7ab2.png)

Then you can step twice again to execute the message node and the assignment node and `a` will be equal to 5:

![image](https://user-images.githubusercontent.com/97704417/199505392-c87caaee-961c-40a5-ad1e-761cd9abb691.png)

So, jumpToCaret is very useful if you want to see and debug what happens when a piece of code is executed several times.

* JumpToCaret allows to jump inside a non-inlined (embedded or not) block (= that needs to be evalued and that creates their own context)

In the screenshot below, `a` is equal to 1 and the next instruction that will be executed is the message node `a + 2`, whose receiver value 1 has already been pushed on the stack:

![image](https://user-images.githubusercontent.com/97704417/199506520-7d69c628-2978-4f1c-bf97-7dac8dacc1c8.png)

If we move to caret, inside the block, on the `a + 1` message node, then, as you'd expect, the next instruction that will be executed is the `a + 1` message node inside the block. However, as the block is not inlined, a context has been created for it and it has become the suspended context:

![image](https://user-images.githubusercontent.com/97704417/199507339-ca9dc453-3cd5-45c0-beea-528cf0f896b3.png)

Now, stepping twice will execute the `a + 1` message node and the ` a := a + 1` assignment node AND the block return. So the result of the block is put on the stack. After exiting the block context via these steps,  you go back in the parent context right after the block creation:

![image](https://user-images.githubusercontent.com/97704417/199509395-288f55fb-6055-4825-9269-6f10760f300b.png)

You should be really careful when exiting a block via steps if you have entered this block via the jumpToCaret command, as the result of the block is pushed on the stack and becomes the argument of the next bytecode that should be executed (as its real argument had already been pushed on the stack before jumping to caret). If this is not intended, you should reexecute the jumpToCaret command to jump to where you are in order to clean the stack: 

![image](https://user-images.githubusercontent.com/97704417/199509590-0998176f-997e-4453-bc84-014837dee0fb.png)

After jumping to caret, the stack has been cleaned (stackTop is not 2 that was the result of the block anymore).

Note that you can enter embedded blocks. In this case, as many contexts as there are embedding levels are created:

![image](https://user-images.githubusercontent.com/97704417/199510368-c246ef15-36dc-46c4-8e14-6a837861d81e.png)

![image](https://user-images.githubusercontent.com/97704417/199510514-9e4971b8-4448-4af8-a68a-962a7b560d55.png)

So, jumpToCaret is useful to see and debug what happens when a block that is never evaluated is actually evaluated.

* jumpToCaret allows to jump outside a block (whether it's embedded or not)

In the screenshot below, we have entered an embedded block thanks to the `jumpToCaret` command and the next instruction that is going to be executed is the `a + 1` message node:

![image](https://user-images.githubusercontent.com/97704417/199511658-c69d2961-9175-4f7f-b216-7e8b244e6019.png)

After jumping to caret outside the block, on the `a + 2` message node, then as this message node is in the home context method node, all contexts above the suspended context are discarded and, as you'd expect, the next instruction that is going to be executed is the `a + 2` message node:

![image](https://user-images.githubusercontent.com/97704417/199512309-00714bb2-a7be-4ff9-b623-d5463c1e9cc1.png)

Note that if the aimed node was outside the suspended context block node, but inside another context (let's call it C) block node whose context is between the suspended context and its home context, then only the contexts above the context C are discarded:

![image](https://user-images.githubusercontent.com/97704417/199513271-05f6efd4-2459-4e96-80a7-7502e6a4c32c.png)

![image](https://user-images.githubusercontent.com/97704417/199513315-c39578e9-157f-4a71-b43c-13d4cd1ebec4.png)

So, jumpToCaret is useful to exit non-inlined blocks, in order to go back to a context between its sender context and its home context, without executing the rest of the block closure.

- What you cannot do with jumpToCaret:

* As skipUpTo, jumpToCaret does not allow to skip return nodes.

Except when the return node is in a non-inlined block (non-local return) as jumping outside non-inlined block discards the entire context, it is not possible to jump over a return bytecode.

This is a problem inherited from skipUpTo, as we didn't allow skipUpTo to skip return bytecodes because a context needs to return something.

Of course, you will never see any code after a return node that is not in a block because Pharo does not allow to write unreachable code (except in DoIts and unreachable code after ifTrue: ifFalse: blocks that contain returns , but we don't take these cases into account, as anyway this code is never executed normally).

However, this can become a problem in the case below:

![image](https://user-images.githubusercontent.com/97704417/199517675-f0bcab0b-bae3-4c4e-b52b-e5c7e468d2ae.png)

Here, we want to jump to caret on the `a := 3` assignment node, after an ifFalse: ifTrue: message. However, jumping to caret does not stop on the assignment but it stops on the return node in  the `ifTrue:` block because it has a return node and this block is inlined in the method bytecode, before the aimed node:

![image](https://user-images.githubusercontent.com/97704417/199518649-00390554-e134-407a-8080-33a989c355d3.png)

The bug also appears with skipUpTo and this is a problem as the assignment `a := 3` is reachable so this should be possible to jump to it.

Here, it is possible to go there without executing anything by:
° jump to caret at the end of the ifFalse: block : 

![image](https://user-images.githubusercontent.com/97704417/199519522-642f3987-3ff1-4818-94af-72147d433fc4.png)

° skipping the last instruction of the ifFalse: block that doesn't return: 

![image](https://user-images.githubusercontent.com/97704417/199519947-a93d1a15-f92f-4164-83c4-d99295749406.png)

![image](https://user-images.githubusercontent.com/97704417/199520501-2f753095-f580-488b-aa4c-15309b5e39a9.png)

° stepping over (that keeps the program state as it is. Here, it just jumps after the ifTrue: block as it considers that the ifFalse: block has been executed):

![image](https://user-images.githubusercontent.com/97704417/199520790-cbe41b96-7fc9-4f23-95d5-97471806f269.png)

However this is really tedious and we have to think about a way to make it work. Furthermore, there are some cases for which no easy workaround exists. In the screenshot below, we want to enter the inlined ifTrue: block in the ifTrue:ifFalse: message:

![image](https://user-images.githubusercontent.com/97704417/199521325-3ed96839-e11b-4765-aed6-402aa6d24cf5.png)

After jumping to caret, we stop on the return node in the inlined ifFalse: block because it is before the inlined ifTrue: block:

![image](https://user-images.githubusercontent.com/97704417/199521790-7b5d72d0-0778-4035-ae07-5bf064efa970.png)

Implementation notes:
- 
  * We get the AST node associated to the caret and get the first PC in the method associated to the AST node. If it is nil, then we check if the node is actually in the method (or block) node. If it is not in the method node and if it is not in the home context method node, we signal an error.  If it is not in the method node but if it is in the home context method node, that means we want to exit a block and we discard the contexts above to exit the block and jump to the aimed node in this context.
  * If the aimedPC for the aimed node is nil and if the aimed node is a recursive child of the method node (this is the case for variable nodes in assignments for example), then we get the first node that is executed after the aimed node and that has a PC associated to it and then we move to the first PC associated to this node instead. If this node is a block node, then this means that we want to enter a block. Then after having jumped to the block creation, we step the block creation bytecode to get the block closure and create a new context for it. We set this new block context as the suspended context in the process and the debug session and we recursively `moveToNode:` to jump to the aimed node in the new context.
- In the implementation, I work with AST node identity, because, for instance if we want to jump to an RBLiteralValueNode 1, we want to jump to this specific node and not any other RBLiteralValueNode 1 that could be anywhere else in the method node.

Known related issues:
- #55 (minor issue)
- return node in inlined block issue (annoying issue that prevents to use this command at full power but does not induce any crash)