### PR TITLE
compiling missing method when loading master or Pharo12 in P12, because it deletes a method from the entire system, while it should ONLY delete it from Sindarin

### DIFF
--- a/src/BaselineOfSindarin/BaselineOfSindarin.class.st
+++ b/src/BaselineOfSindarin/BaselineOfSindarin.class.st
@@ -6,17 +6,31 @@ Class {
 
 { #category : #baselines }
 BaselineOfSindarin >> baseline: spec [
+
 	<baseline>
-	
+	spec for: #common do: [
+		spec postLoadDoIt: #postloadWithLoader:withPackageSpec:.
+
+		spec
+			package: 'Sindarin';
+			package: 'Sindarin-Tests';
+			package: 'Sindarin-Experiments' ].
+
 	spec
-		for: #common
-		do: [
-			spec
-				package: 'Sindarin';
-				package: 'Sindarin-Tests';
-				package: 'Sindarin-Experiments' ].
-			
-	spec 
-		group: 'default' with: #( 'Sindarin' 'Sindarin-Tests');
-		group: 'experiments' with: #('default' 'Sindarin-Experiments')
+		group: 'default' with: #( 'Sindarin' 'Sindarin-Tests' );
+		group: 'experiments' with: #( 'default' 'Sindarin-Experiments' )
+]
+
+{ #category : #baselines }
+BaselineOfSindarin >> postloadWithLoader: loader withPackageSpec: spec [
+
+	InstructionStream compiledMethodAt: #willJumpIfFalse ifAbsent: [
+		Smalltalk compiler
+			source: 'willJumpIfFalse
+	"Answer whether the next bytecode is a jump-if-false."
+
+	^ self method encoderClass isBranchIfFalseAt: pc in: self method';
+			class: InstructionStream;
+			compile;
+			install ]
 ]


### PR DESCRIPTION
consequence of: https://github.com/pharo-spec/ScriptableDebugger/pull/65 and fixes https://github.com/pharo-spec/NewTools/issues/538