### PR TITLE
Fix: skip up to does not allow to skip return nodes which prevents from skipping up to an inlined if true block if there is an inlined if false block before

### DIFF
--- a/src/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -146,6 +146,18 @@ SindarinDebuggerTest >> methodWithSeveralInstructionsInBlock [
 ]
 
 { #category : #helpers }
+SindarinDebuggerTest >> methodWithSeveralReturns [
+	"There is only one explicit return  but there is also an implicit return after `a := 3`. In that sense, there are several returns in this method"
+
+	| a |
+	a := true.
+	a
+		ifFalse: [ ^ a := 1 ]
+		ifTrue: [ a := 2 ].
+	a := 3
+]
+
+{ #category : #helpers }
 SindarinDebuggerTest >> methodWithTwoAssignments [
 
 	| a |
@@ -1309,6 +1321,52 @@ SindarinDebuggerTest >> testSkipBlockNode [
 
 	self assert: scdbg context identicalTo: targetContext.
 	self assert: scdbg topStack equals: 43
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipCanSkipReturnIfItIsNotTheLastReturn [
+
+	| scdbg |
+	scdbg := SindarinDebugger debug: [ self methodWithSeveralReturns ].
+
+	"we step until we arrive on the node `^ a := 1` in `SindarinDebuggerTest>>#methodWithSeveralReturns`."
+	scdbg
+		step;
+		skip;
+		skip;
+		step.
+
+	self assert: scdbg node isReturn.
+	self assert: scdbg topStack equals: 1.
+
+	"We skip the return node"
+	self shouldnt: [ scdbg skip ] raise: SindarinSkippingReturnWarning.
+
+	"We should be on the `a := 2` node"
+	self assert: scdbg node isAssignment.
+	self assert: scdbg node value value equals: 2
+]
+
+{ #category : #tests }
+SindarinDebuggerTest >> testSkipCannotSkipReturnIfItIsTheLastReturn [
+
+	| scdbg nodeWithImplicitReturn |
+	scdbg := SindarinDebugger debug: [ self methodWithSeveralReturns ].
+
+	"we step until we arrive on the method node in `SindarinDebuggerTest>>#methodWithSeveralReturns`, which is mapped to the implicit return bycode."
+	scdbg step.
+	nodeWithImplicitReturn := scdbg methodNode.
+	3 timesRepeat: [ scdbg step ].
+
+	self assert: scdbg node identicalTo: nodeWithImplicitReturn.
+	self assert: scdbg instructionStream willReturn.
+
+	"We skip the return node"
+	self should: [ scdbg skip ] raise: SindarinSkippingReturnWarning.
+
+	"We should still be on the method node"
+	self assert: scdbg node identicalTo: nodeWithImplicitReturn.
+	self assert: scdbg instructionStream willReturn
 ]
 
 { #category : #tests }

--- a/src/Sindarin/SindarinDebugger.class.st
+++ b/src/Sindarin/SindarinDebugger.class.st
@@ -424,8 +424,20 @@ SindarinDebugger >> skipMessageNodeWith: replacementValue [
 { #category : #'stepping -  skip' }
 SindarinDebugger >> skipReturnNode [
 
-	self flag: 'We should be able to skip a return node as long as it''s not the last one in the method'.
-	^ SindarinSkippingReturnWarning signal: 'Cannot skip a return node'
+	| node allReturnNodes |
+	node := self node.
+
+	"We collect the list of nodes associated to a return bytecode, via the IR"
+	allReturnNodes := self method ir children flatCollect: [ :irSequence |
+		                  irSequence sequence
+			                  select: [ :irInstruction |
+			                  irInstruction isReturn ]
+			                  thenCollect: [ :irInstruction |
+			                  irInstruction sourceNode ] ].
+	"If this is the last node of the method that is mapped to a return bytecode, we can't skip it and we stop there."
+	node == allReturnNodes last ifTrue: [
+		^ SindarinSkippingReturnWarning signal:
+			  'Cannot skip the last return in the method' ]
 ]
 
 { #category : #'stepping -  skip' }

--- a/src/Sindarin/SindarinDebugger.class.st
+++ b/src/Sindarin/SindarinDebugger.class.st
@@ -437,7 +437,11 @@ SindarinDebugger >> skipReturnNode [
 	"If this is the last node of the method that is mapped to a return bytecode, we can't skip it and we stop there."
 	node == allReturnNodes last ifTrue: [
 		^ SindarinSkippingReturnWarning signal:
-			  'Cannot skip the last return in the method' ]
+			  'Cannot skip the last return in the method' ].
+
+	self skipPcToNextBytecode.
+	self debugSession stepToFirstInterestingBytecodeWithJumpIn:
+		self debugSession interruptedProcess
 ]
 
 { #category : #'stepping -  skip' }


### PR DESCRIPTION
Fixes #57 for master (and P12)

When using `skipUpTo` or `jumpToCaret` command, the debugger couldn't go beyond any return, even if it was in an ifTrue:IfFalse: block.

I changed the behavior so that it can skip a return as long as this is not the last reachable return in the current context