### PR TITLE
Fixing: jump to caret does not keep a correct stack when there are vector arrays to store common variables between methods and blocks

### DIFF
--- a/src/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -125,6 +125,16 @@ SindarinDebuggerTest >> methodWithNotEvaluatedBlock [
 ]
 
 { #category : #helpers }
+SindarinDebuggerTest >> methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement [
+
+	| a block |
+ 	block := [ a := a + 1 ].
+ 	a := 1.
+ 	a := a + 2.
+ 	^ a * 42
+]
+
+{ #category : #helpers }
 SindarinDebuggerTest >> methodWithOneAssignment [
 
 	| a |
@@ -917,6 +927,43 @@ SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToNodeThatI
 	"2 has not been assigned to a"
 	self assert: (sdbg readVariableNamed: #a) equals: 1.
 	self assert: sdbg topStack equals: 2
+]
+
+{ #category : #helpers }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBlockCreationIsFirstBytecodeInFirstStatement [
+
+	| aimedBlock sdbg aimedNode |
+	sdbg := SindarinDebugger debug: [
+		        self
+			        methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement ].
+	"We step until the `a * 42` node"
+	sdbg step.
+	6 timesRepeat: [ sdbg stepOver ].
+
+	self assert: sdbg method identicalTo: self class
+		>>
+		#methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement.
+	self assert: (sdbg readVariableNamed: #a) identicalTo: 3.
+
+	"We jump to the node `a + 1` inside the block"
+	aimedBlock := sdbg methodNode statements first value.
+	aimedNode := aimedBlock body statements first value.
+	sdbg moveToNode: aimedNode.
+
+	"We are in the block context"
+	self assert: sdbg method ast identicalTo: aimedBlock.
+	"The block context can also read #a"
+	self assert: (sdbg readVariableNamed: #a) identicalTo: 3.
+
+	"We step the entire block"
+	3 timesRepeat: [ sdbg stepOver ].
+
+	"We are back in the context method"
+	self assert: sdbg method identicalTo: self class
+		>>
+		#methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement.
+	"We can still read #a in the method context"
+	self assert: (sdbg readVariableNamed: #a) identicalTo: 4
 ]
 
 { #category : #tests }

--- a/src/Sindarin/SindarinDebugger.class.st
+++ b/src/Sindarin/SindarinDebugger.class.st
@@ -243,13 +243,12 @@ SindarinDebugger >> nextExecutedNodeAfter: aNode [
 
 { #category : #'API - changes' }
 SindarinDebugger >> pc: anInteger [
-
 	"Allows to move to the first PC associated to the node to which anInteger is associated. anInteger must be a valid pc in the suspended context"
 
 	| nextNode methodNode firstPCOfStatementNode |
 	"If aimedPC is outside the context PCs range, then an error is signaled"
-	(anInteger < self method initialPC or: [ 
-		 anInteger > self method endPC ]) ifTrue: [ 
+	(anInteger < self method initialPC or: [
+		 anInteger > self method endPC ]) ifTrue: [
 		^ NotValidPcError signal ].
 	methodNode := self methodNode.
 	nextNode := methodNode sourceNodeForPC: anInteger.
@@ -261,6 +260,12 @@ SindarinDebugger >> pc: anInteger [
 				                          methodNode statements first.
 			self cleanStack ].
 	self context pc: firstPCOfStatementNode.
+
+	"If the first pc of the first statement is mapped to a block creation. That means that it needs the associated temp vector on top of the stack. The bytecode that pushes this vector on the stack precedes the block creation. So, here, this bytecode is mapped to the method node and has been skipped. Thus, we go back to the previous bytecode to execute it."
+	self instructionStream willCreateBlock ifTrue: [
+		self context pc: self instructionStream previousPc.
+		self stepBytecode ].
+
 	self debugSession stepToFirstInterestingBytecodeIn:
 		self debugSession interruptedProcess.
 	self skipUpToNode: nextNode


### PR DESCRIPTION
Fixes #55 

When we jump to caret to a node inside a block, we go to first pc of the first statement  and we skip until the block creation to step it in order to get the created closure. Creating the closure requires to push a temp vector on the stack. This temp vector is not mapped to the AST block, but to the node preceding the block.

If the block creation is the first bytecode in the first statement in the method, then this pushVector bytecode is mapped to the method node. However, we skip all bytecodes mapped to the method node because otherwise it would recreate all temps and that's not what we want when we perform `jumpToCaret:`.

So, if we perform a jumpToCaret to go into a block that whose creation is the first bytecode in the first statement, then the pushVector bytecode is not executed. As a result, it messes up the stack in both contexts which will ultimately lead to errors.

I fixed this behavior so that, when we go back to the first pc of the first statement, if the associated bytecode is a block creation, I go back to the previous bytecode (which is the pushVector bytecode) to step it to ensure that the stack is correct.