### PR TITLE
[P11] Fixing: jump to caret does not keep a correct stack when there are vector arrays to store common variables between methods and blocks

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -124,6 +124,16 @@ SindarinDebuggerTest >> methodWithNotEvaluatedBlock [
 	^ a * 42
 ]
 
+{ #category : #tests }
+SindarinDebuggerTest >> methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement [
+
+	| a block |
+ 	block := [ a := a + 1 ].
+ 	a := 1.
+ 	a := a + 2.
+ 	^ a * 42
+]
+
 { #category : #helpers }
 SindarinDebuggerTest >> methodWithOneAssignment [
 
@@ -885,6 +895,43 @@ SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToNodeThatI
 	"2 has not been assigned to a"
 	self assert: (sdbg temporaryNamed: #a) equals: 1.
 	self assert: sdbg topStack equals: 2
+]
+
+{ #category : #helpers }
+SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBlockCreationIsFirstBytecodeInFirstStatement [
+
+	| aimedBlock sdbg aimedNode |
+	sdbg := SindarinDebugger debug: [
+		        self
+			        methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement ].
+	"We step until the `a * 42` node"
+	sdbg step.
+	6 timesRepeat: [ sdbg stepOver ].
+
+	self assert: sdbg method identicalTo: self class
+		>>
+		#methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement.
+	self assert: (sdbg temporaryNamed: #a) identicalTo: 3.
+
+	"We jump to the node `a + 1` inside the block"
+	aimedBlock := sdbg methodNode statements first value.
+	aimedNode := aimedBlock body statements first value.
+	sdbg moveToNode: aimedNode.
+
+	"We are in the block context"
+	self assert: sdbg method ast identicalTo: aimedBlock.
+	"The block context can also read #a"
+	self assert: (sdbg temporaryNamed: #a) identicalTo: 3.
+
+	"We step the entire block"
+	3 timesRepeat: [ sdbg stepOver ].
+
+	"We are back in the context method"
+	self assert: sdbg method identicalTo: self class
+		>>
+		#methodWithNotEvaluatedBlockWhoseCreationIsFirstBytecodeInFirstStatement.
+	"We can still read #a in the method context"
+	self assert: (sdbg temporaryNamed: #a) identicalTo: 4
 ]
 
 { #category : #tests }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -457,13 +457,12 @@ SindarinDebugger >> pc [
 
 { #category : #accessing }
 SindarinDebugger >> pc: anInteger [
-
 	"Allows to move to the first PC associated to the node to which anInteger is associated. anInteger must be a valid pc in the suspended context"
 
 	| nextNode methodNode firstPCOfStatementNode |
 	"If aimedPC is outside the context PCs range, then an error is signaled"
-	(anInteger < self method initialPC or: [ 
-		 anInteger > self method endPC ]) ifTrue: [ 
+	(anInteger < self method initialPC or: [
+		 anInteger > self method endPC ]) ifTrue: [
 		^ NotValidPcError signal ].
 	methodNode := self methodNode.
 	nextNode := methodNode sourceNodeForPC: anInteger.
@@ -475,6 +474,12 @@ SindarinDebugger >> pc: anInteger [
 				                          methodNode statements first.
 			self cleanStack ].
 	self context pc: firstPCOfStatementNode.
+
+	"If the first pc of the first statement is mapped to a block creation. That means that it needs the associated temp vector on top of the stack. The bytecode that pushes this vector on the stack precedes the block creation. So, here, this bytecode is mapped to the method node and has been skipped. Thus, we go back to the previous bytecode to execute it."
+	self context instructionStream willCreateBlock ifTrue: [
+		self context pc: self context instructionStream previousPc.
+		self stepBytecode ].
+
 	self debugSession stepToFirstInterestingBytecodeIn:
 		self debugSession interruptedProcess.
 	self skipUpToNode: nextNode


### PR DESCRIPTION
Fixes #55 

Equivalent of #78 for Pharo11