### PR TITLE
Remove unimplemented calls

### DIFF
--- a/src/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -345,7 +345,7 @@ SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnSt
 SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsGreaterThanEndPC [
 
 	| oldPC sdbg |
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg
 		step;
 		stepOver;
@@ -354,7 +354,7 @@ SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsGreaterThanEndPC [
 	self
 		shouldnt: [ sdbg pc: sdbg method endPC ] raise: NotValidPcError;
 		deny: sdbg pc equals: oldPC.
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg
 		step;
 		stepOver;
@@ -369,7 +369,7 @@ SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsGreaterThanEndPC [
 SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
 
 	| scdbg |
-	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	scdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 
 	scdbg
 		step;
@@ -378,7 +378,7 @@ SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
 	
 	self shouldnt: [ scdbg pc: scdbg method initialPC ] raise: NotValidPcError.
 	
-	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	scdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 
 	scdbg
 		step;
@@ -411,7 +411,7 @@ SindarinDebuggerTest >> testChangingPcToNonExistingBytecodeOffsetGoesToPreviousP
 { #category : #tests }
 SindarinDebuggerTest >> testContext [
 	| scdbg |
-	scdbg := SindarinDebugger debug: [ self helperMethod15 ].
+	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
 	self assert: scdbg context equals: scdbg debugSession interruptedContext.
 	scdbg step.
 	self assert: scdbg context equals: scdbg debugSession interruptedContext
@@ -690,7 +690,7 @@ SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNode [
 SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNodeThatDoesNotHaveAssociatedPC [
 
 	| scdbg newPc newNode realPC realNode |
-	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	scdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 
 	scdbg
 		step;
@@ -717,7 +717,7 @@ SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNodeThatDoe
 SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeInMethod [
 
 	| oldNode sdbg aimedNode |
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg
 		step;
 		stepOver.
@@ -729,7 +729,7 @@ SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeIn
 	self
 		shouldnt: [ sdbg moveToNode: aimedNode ] raise: NodeNotInASTError;
 		assert: sdbg node equals: aimedNode.
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg
 		step;
 		stepOver;
@@ -745,7 +745,7 @@ SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeIn
 SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotInMethod [
 
 	| oldNode sdbg |
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg
 		step;
 		stepOver;
@@ -755,7 +755,7 @@ SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotInMethod [
 		shouldnt: [ sdbg moveToNode: sdbg methodNode statements last ]
 		raise: NodeNotInASTError;
 		deny: sdbg node equals: oldNode.
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg
 		step;
 		stepOver;
@@ -1739,7 +1739,7 @@ SindarinDebuggerTest >> testStatementNodeContaining [
 SindarinDebuggerTest >> testStatementNodeContainingReturnsStatementNodeThatContainsTheIdenticalSubtree [
 
 	| sdbg |
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg step.
 
 	"1 is in the tree but it should return its parent only if we provide the exact literal node"
@@ -1752,7 +1752,7 @@ SindarinDebuggerTest >> testStatementNodeContainingReturnsStatementNodeThatConta
 SindarinDebuggerTest >> testStatementNodeContainingWhenNodeIsNotInAST [
 
 	| sdbg |
-	sdbg := SindarinDebugger debug: [ self helperMethod1 ].
+	sdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
 	sdbg step.
 
 	self


### PR DESCRIPTION
See discussion there: https://github.com/pharo-spec/ScriptableDebugger/pull/76

Remove unimplemented method calls to use the right methods 