### PR TITLE
See issue #15631 and PR #15632 Fix a bug in return simulation for an …

### DIFF
--- a/src/Sindarin-Tests/SindarinDebugSessionMock.class.st
+++ b/src/Sindarin-Tests/SindarinDebugSessionMock.class.st
@@ -2,80 +2,82 @@
 I mock sindarin debug sessions to control it finely during tests
 "
 Class {
-	#name : #SindarinDebugSessionMock,
-	#superclass : #Object,
+	#name : 'SindarinDebugSessionMock',
+	#superclass : 'Object',
 	#instVars : [
 		'isMessage',
 		'selector',
 		'receiver'
 	],
-	#category : #'Sindarin-Tests-Mocks'
+	#category : 'Sindarin-Tests-Mocks',
+	#package : 'Sindarin-Tests',
+	#tag : 'Mocks'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> context [
 	 ^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> debugSession [
 	 ^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> interruptedContext [
 	 ^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> isMessage [
 	 ^isMessage ifNil:[false]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> isMessage: anObject [
 
 	isMessage := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> method [
 	 ^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> pc [
 	 ^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> receiver [
 	 ^receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> receiver: anObject [
 
 	receiver := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> selector [
 	^selector 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> selector: anObject [
 
 	selector := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> sourceNodeExecuted [
 	 ^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SindarinDebugSessionMock >> sourceNodeForPC: pc [
 	 ^self
 ]

--- a/src/Sindarin-Tests/SindarinDebugSessionTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebugSessionTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #SindarinDebugSessionTest,
-	#superclass : #TestCase,
+	#name : 'SindarinDebugSessionTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'debugSession',
 		'sindarinSession'
 	],
-	#category : #'Sindarin-Tests-Base'
+	#category : 'Sindarin-Tests-Base',
+	#package : 'Sindarin-Tests',
+	#tag : 'Base'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SindarinDebugSessionTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 	
@@ -17,13 +19,13 @@ SindarinDebugSessionTest >> setUp [
 	sindarinSession := debugSession asSindarinDebugSession
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebugSessionTest >> testDebugSessionAsSindarinDebugSession [
 
 	self assert: sindarinSession debugSession identicalTo: debugSession
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebugSessionTest >> testSindarinSessionAsSindarinDebugSession [
 
 	self
@@ -31,7 +33,7 @@ SindarinDebugSessionTest >> testSindarinSessionAsSindarinDebugSession [
 		identicalTo: sindarinSession
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebugSessionTest >> testSindarinSessionInstantiation [
 
 	| sessionName process |

--- a/src/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -1,13 +1,21 @@
 Class {
-	#name : #SindarinDebuggerTest,
-	#superclass : #TestCase,
+	#name : 'SindarinDebuggerTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'testObjectPoint'
 	],
-	#category : #'Sindarin-Tests-Base'
+	#category : 'Sindarin-Tests-Base',
+	#package : 'Sindarin-Tests',
+	#tag : 'Base'
 }
 
-{ #category : #helpers }
+{ #category : 'testing' }
+SindarinDebuggerTest >> expectedFailures [
+
+	^ #( testIsExecutionFinished testStepOverFinishedExecution )
+]
+
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodNonLocalReturn [
 	| block |
 	block := [ ^ 42 ].
@@ -15,7 +23,7 @@ SindarinDebuggerTest >> methodNonLocalReturn [
 	^ 43
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodReturn: bool with: anObject [
 
 	| a |
@@ -24,7 +32,7 @@ SindarinDebuggerTest >> methodReturn: bool with: anObject [
 	^ anObject
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodReturnWithException [
 
 	| a |
@@ -33,7 +41,7 @@ SindarinDebuggerTest >> methodReturnWithException [
 	^ a + 1
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodReturnWithHalt [
 	<haltOrBreakpointForTesting>
 
@@ -43,7 +51,7 @@ SindarinDebuggerTest >> methodReturnWithHalt [
 	^ a + 1
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithBlockWithNoReturn [
 
 	| block a |
@@ -52,20 +60,20 @@ SindarinDebuggerTest >> methodWithBlockWithNoReturn [
 	^ 43
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithContextPassedToBlockParameter: storeContextBlock [
 
 	storeContextBlock value: thisContext
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithDoubleAssignment [
 
 	| b a |
 	a := b :=  1
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithEmbeddedBlock [
 
 	| a |
@@ -75,7 +83,7 @@ SindarinDebuggerTest >> methodWithEmbeddedBlock [
 	^ a * 42
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithEvaluatedBlock [
 
 	| a b block |
@@ -86,7 +94,7 @@ SindarinDebuggerTest >> methodWithEvaluatedBlock [
 	
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithIfTrueBlock [
 
 	| a |
@@ -95,7 +103,7 @@ SindarinDebuggerTest >> methodWithIfTrueBlock [
 	a := 4
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> methodWithIfTrueIfFalse [
 
 	| a |
@@ -106,7 +114,7 @@ SindarinDebuggerTest >> methodWithIfTrueIfFalse [
 	a := 3
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithImplicitReturn [
 
 	testObjectPoint sign.
@@ -114,7 +122,7 @@ SindarinDebuggerTest >> methodWithImplicitReturn [
 	Point new
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithNotEvaluatedBlock [
 
 	| a |
@@ -124,7 +132,7 @@ SindarinDebuggerTest >> methodWithNotEvaluatedBlock [
 	^ a * 42
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithOneAssignment [
 
 	| a |
@@ -132,7 +140,7 @@ SindarinDebuggerTest >> methodWithOneAssignment [
 	^ Point x: 5 y: '3' asInteger
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithSeveralInstructionsInBlock [
 
 	| a b block |
@@ -145,7 +153,7 @@ SindarinDebuggerTest >> methodWithSeveralInstructionsInBlock [
 	^ 42
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SindarinDebuggerTest >> methodWithTwoAssignments [
 
 	| a |
@@ -154,12 +162,12 @@ SindarinDebuggerTest >> methodWithTwoAssignments [
 	^ Point x: 5 y: '3' asInteger
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SindarinDebuggerTest >> runCaseManaged [
 	^ self runCase
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SindarinDebuggerTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 
@@ -168,13 +176,13 @@ SindarinDebuggerTest >> setUp [
 	testObjectPoint := Point x: 1 y: 2
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SindarinDebuggerTest >> tearDown [
 
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testArguments [
 	| p scdbg |
 	p := Point new.
@@ -186,7 +194,7 @@ SindarinDebuggerTest >> testArguments [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testAssignmentValue [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -194,7 +202,7 @@ SindarinDebuggerTest >> testAssignmentValue [
 	self assert: scdbg assignmentValue equals: 5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testAssignmentVariableName [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -202,7 +210,7 @@ SindarinDebuggerTest >> testAssignmentVariableName [
 	self assert: scdbg assignmentVariableName equals: #a
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsAfterInAnyContext [
 
 	| sdbg aimedNodeInContext aimedNodeOutsideContext |
@@ -230,7 +238,7 @@ SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsAfterInAnyContext [
 	self assert: (sdbg canStillExecute: aimedNodeOutsideContext)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsBeforeInAnyContext [
 
 	| sdbg aimedNodeInContext aimedNodeOutsideContext |
@@ -258,7 +266,7 @@ SindarinDebuggerTest >> testCanStillExecuteWhenAimedNodePcIsBeforeInAnyContext [
 	self deny: (sdbg canStillExecute: aimedNodeOutsideContext)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testChangingPcAssociatedToMethodOrSequenceNodeKeepsStackAsItIs [
 
 	| scdbg newPc newNode expectedStackTop |
@@ -279,7 +287,7 @@ SindarinDebuggerTest >> testChangingPcAssociatedToMethodOrSequenceNodeKeepsStack
 	self assert: scdbg topStack equals: expectedStackTop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testChangingPcInTheMiddleOfStatementSkipsTheBeginningOfStatement [
 
 	| scdbg newPc newNode expectedStackTop |
@@ -314,7 +322,7 @@ SindarinDebuggerTest >> testChangingPcInTheMiddleOfStatementSkipsTheBeginningOfS
 	self assert: scdbg topStack equals: '3' "topStack is nil because the message send asInteger to the receiver '3' has been skipped"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnStack [
 
 	| scdbg newPc newNode expectedStackTop |
@@ -341,7 +349,7 @@ SindarinDebuggerTest >> testChangingPcKeepsSameStateAndPushesCorrectElementsOnSt
 	self assert: scdbg topStack equals: expectedStackTop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsGreaterThanEndPC [
 
 	| oldPC sdbg |
@@ -365,7 +373,7 @@ SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsGreaterThanEndPC [
 		assert: sdbg pc equals: oldPC
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
 
 	| scdbg |
@@ -388,7 +396,7 @@ SindarinDebuggerTest >> testChangingPcRaisesErrorWhenPcIsLowerThanInitialPC [
 	self should: [ scdbg pc: scdbg method initialPC - 1 ] raise: NotValidPcError.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testChangingPcToNonExistingBytecodeOffsetGoesToPreviousPcWithExistingBytecodeOffset [
 
 	| scdbg newPc newNode |
@@ -408,7 +416,7 @@ SindarinDebuggerTest >> testChangingPcToNonExistingBytecodeOffsetGoesToPreviousP
 	self assert: scdbg pc equals: newPc - 1.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testContext [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -417,7 +425,7 @@ SindarinDebuggerTest >> testContext [
 	self assert: scdbg context equals: scdbg debugSession interruptedContext
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testContinue [
 
 	| scdbg |
@@ -432,7 +440,7 @@ SindarinDebuggerTest >> testContinue [
 	self assert: scdbg isExecutionFinished
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testContinueEncoutersAnException [
 
 	| scdbg |
@@ -447,7 +455,7 @@ SindarinDebuggerTest >> testContinueEncoutersAnException [
 	self assert: scdbg isAboutToSignalException
 ]
 
-{ #category : #'tests - execution predicates' }
+{ #category : 'tests - execution predicates' }
 SindarinDebuggerTest >> testIsAboutToInstantiateClass [
 
 	|debugger session|
@@ -487,7 +495,7 @@ SindarinDebuggerTest >> testIsAboutToInstantiateClass [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testIsAssignment [
 
 	| scdbg |
@@ -499,7 +507,7 @@ SindarinDebuggerTest >> testIsAssignment [
 	self deny: scdbg isAssignment
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testIsExecutionFinished [
 
 	| scdbg |
@@ -511,7 +519,7 @@ SindarinDebuggerTest >> testIsExecutionFinished [
 	self assert: scdbg currentProcess isTerminated
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testIsMessageSend [
 
 	| scdbg |
@@ -523,7 +531,7 @@ SindarinDebuggerTest >> testIsMessageSend [
 	self assert: scdbg isMessageSend
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMessage [
 
 	| scdbg |
@@ -531,7 +539,7 @@ SindarinDebuggerTest >> testMessage [
 	self assert: (scdbg message: #methodWithOneAssignment)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMessageArguments [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -542,7 +550,7 @@ SindarinDebuggerTest >> testMessageArguments [
 	self assert: (scdbg messageArguments at: 2) equals: 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMessageReceiver [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -551,7 +559,7 @@ SindarinDebuggerTest >> testMessageReceiver [
 	self assert: scdbg messageReceiver equals: '3'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMessageSelector [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -562,7 +570,7 @@ SindarinDebuggerTest >> testMessageSelector [
 	self assert: scdbg messageSelector equals: #x:y:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMessageTo [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithImplicitReturn ].
@@ -580,7 +588,7 @@ SindarinDebuggerTest >> testMessageTo [
 	self deny: (scdbg message: #extent: to: Point new)	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMessageToInstanceOf [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithImplicitReturn ].
@@ -591,7 +599,7 @@ SindarinDebuggerTest >> testMessageToInstanceOf [
 	self deny: (scdbg message: #bogus toInstanceOf: Point)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMethod [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment  ].	
@@ -602,7 +610,7 @@ SindarinDebuggerTest >> testMethod [
 	self assert: scdbg method equals: String>>#asInteger
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeInTheMiddleOfStatementSkipsTheBeginningOfStatement [
 
 	| scdbg newPc newNode expectedStackTop |
@@ -637,7 +645,7 @@ SindarinDebuggerTest >> testMoveToNodeInTheMiddleOfStatementSkipsTheBeginningOfS
 	self assert: scdbg topStack equals: '3' "topStack is nil because the message send asInteger to the receiver '3' has been skipped"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeKeepsSameStateAndPushesCorrectElementsOnStack [
 
 	| scdbg newPc newNode expectedStackTop |
@@ -664,7 +672,7 @@ SindarinDebuggerTest >> testMoveToNodeKeepsSameStateAndPushesCorrectElementsOnSt
 	self assert: scdbg topStack equals: expectedStackTop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNode [
 
 	| scdbg newPc newNode expectedStackTop |
@@ -686,7 +694,7 @@ SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNode [
 	self assert: scdbg topStack equals: expectedStackTop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNodeThatDoesNotHaveAssociatedPC [
 
 	| scdbg newPc newNode realPC realNode |
@@ -713,7 +721,7 @@ SindarinDebuggerTest >> testMoveToNodeKeepsStackWhenAimedNodeIsMethodNodeThatDoe
 		identicalTo: (scdbg methodNode sourceNodeForPC: scdbg pc)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeInMethod [
 
 	| oldNode sdbg aimedNode |
@@ -741,7 +749,7 @@ SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotIdenticalToANodeIn
 		assert: sdbg node equals: oldNode
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotInMethod [
 
 	| oldNode sdbg |
@@ -767,7 +775,7 @@ SindarinDebuggerTest >> testMoveToNodeRaisesErrorWhenNodeIsNotInMethod [
 		assert: sdbg node equals: oldNode
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedBlockToOuterContext [
 
 	| oldNode sdbg aimedNode oldContext aimedPC methodNode |
@@ -816,7 +824,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedBlockToOuterContext [
 	self assert: sdbg topStack equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToHomeContext [
 
 	| oldNode sdbg aimedNode oldContext aimedPC methodNode |
@@ -865,7 +873,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToHomeConte
 	self assert: sdbg topStack equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToNodeThatIsNotInHomeContext [
 
 	| oldNode oldPC sdbg aimedNode oldContext aimedPC methodNode |
@@ -919,7 +927,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenFromNonInlinedEmbeddedBlockToNodeThatI
 	self assert: sdbg topStack equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBlockHasBeenCreated [
 
 	| oldNode sdbg aimedNode oldContext aimedPC |
@@ -965,7 +973,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBloc
 	self assert: sdbg topStack equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBlockHasBeenCreatedBackward [
 
 	| oldNode sdbg aimedNode oldContext aimedPC |
@@ -1010,7 +1018,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInBlockThatCreatesContextAndBloc
 	self assert: sdbg topStack equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInIfTrueIfFalseBlock [
 
 	| oldNode sdbg aimedNode oldContext aimedPC |
@@ -1048,7 +1056,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsInIfTrueIfFalseBlock [
 	self assert: (sdbg readVariableNamed: #a) equals: 4
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableExecutesAssociatedBytecodesBecauseRelatedToStack [
 
 	| oldNode sdbg aimedNode siblingsAfterAimedNode indexOfAimedNode realNode indexOfRealNode |
@@ -1080,7 +1088,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableExecutesAssocia
 	self deny: (realNode isLiteralNode or: [ realNode isVariable ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableThatHasNoAssociatedBytecodesMovesToNextNodeThatIsNotLiteralNorVariableThatHasAnAssociatedPC [
 
 	| oldNode sdbg aimedNode siblingsAfterAimedNode indexOfAimedNode realNode indexOfRealNode |
@@ -1121,7 +1129,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsLiteralOrVariableThatHasNoAssoci
 		deny: (sdbg methodNode pcsForNode: realNode) isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testMoveToNodeWhenNodeIsNonInlinedAndEmbeddedInNonInlinedBlock [
 
 	| oldNode sdbg aimedNode oldContext aimedPC methodNode |
@@ -1177,7 +1185,7 @@ SindarinDebuggerTest >> testMoveToNodeWhenNodeIsNonInlinedAndEmbeddedInNonInline
 	self assert: sdbg context identicalTo: oldContext.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testNode [
 	| node scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithTwoAssignments ].
@@ -1195,7 +1203,7 @@ SindarinDebuggerTest >> testNode [
 	self assert: node selector equals: #asInteger
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testPc [
 	| dbg |
 	dbg := SindarinDebugger
@@ -1206,7 +1214,7 @@ SindarinDebuggerTest >> testPc [
 	self assert: dbg pc equals: dbg context pc
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testReceiver [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -1217,7 +1225,7 @@ SindarinDebuggerTest >> testReceiver [
 	self assert: scdbg receiver equals: '3'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSelector [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -1228,7 +1236,7 @@ SindarinDebuggerTest >> testSelector [
 	self assert: scdbg selector equals: #asInteger
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkip [
 	| a p scdbg |
 	a := 1.
@@ -1242,7 +1250,7 @@ SindarinDebuggerTest >> testSkip [
 	self assert: p equals: Point
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipAssignmentWithStoreIntoBytecodePushesReplacementValueButNotWithPopIntoBytecode [
 
 	| a b dbg aFormerValue bFormerValue |
@@ -1271,7 +1279,7 @@ SindarinDebuggerTest >> testSkipAssignmentWithStoreIntoBytecodePushesReplacement
 	self assert: a equals: aFormerValue
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipBlockNode [
 
 	| scdbg targetContext |
@@ -1311,7 +1319,7 @@ SindarinDebuggerTest >> testSkipBlockNode [
 	self assert: scdbg topStack equals: 43
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipDoesNotSkipReturn [
 
 	| a scdbg |
@@ -1321,7 +1329,7 @@ SindarinDebuggerTest >> testSkipDoesNotSkipReturn [
 	self should: [ scdbg skip ] raise: SindarinSkippingReturnWarning
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
 
 	| a scdbg |
@@ -1336,7 +1344,7 @@ SindarinDebuggerTest >> testSkipSkipsMessagesByPuttingReceiverOnStack [
  	self assert: a equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipSkipsSuperSendBytecodesCorrectly [
 
 	| a scdbg oldValueOfA negatedContext |
@@ -1355,7 +1363,7 @@ SindarinDebuggerTest >> testSkipSkipsSuperSendBytecodesCorrectly [
 	self assert: a equals: oldValueOfA
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipStepsMethodNodes [
 
 	| scdbg realExecNode realExecPc realTopStack |
@@ -1381,7 +1389,7 @@ SindarinDebuggerTest >> testSkipStepsMethodNodes [
 	self assert: scdbg topStack equals: realTopStack
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipThroughNode [
 	| dbg realExecPC realValueOfA targetExecNode realExecTopStack nodeAfterSkipThrough |
 
@@ -1408,7 +1416,7 @@ SindarinDebuggerTest >> testSkipThroughNode [
 	self assert: dbg topStack equals: '3'
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipToPC [
 	| dbg realExecPC realValueOfA realExecNode realExecTopStack |
 
@@ -1431,7 +1439,7 @@ SindarinDebuggerTest >> testSkipToPC [
 	self assert: dbg topStack equals: realExecTopStack
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipToPcDoesNotLoopWhenAimedPcIsAfterEndPc [
 
 	| sdbg aimedPc pcBeforeSkip |
@@ -1450,7 +1458,7 @@ SindarinDebuggerTest >> testSkipToPcDoesNotLoopWhenAimedPcIsAfterEndPc [
 	self assert: sdbg pc equals: sdbg context endPC.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipToPcDoesNotLoopWhenAimedPcIsBeforeCurrentPc [
 
 	| sdbg aimedPc pcBeforeSkip |
@@ -1470,7 +1478,7 @@ SindarinDebuggerTest >> testSkipToPcDoesNotLoopWhenAimedPcIsBeforeCurrentPc [
 	self assert: sdbg pc equals: pcBeforeSkip.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipUpToIgnoresJumps [
 
 	| sdbg aimedNode aimedPC a |
@@ -1523,7 +1531,7 @@ SindarinDebuggerTest >> testSkipUpToIgnoresJumps [
 		assert: sdbg pc equals: aimedPC
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipUpToNode [
 	| dbg realExecPC realValueOfA realExecNode realExecTopStack |
 
@@ -1546,7 +1554,7 @@ SindarinDebuggerTest >> testSkipUpToNode [
 	self assert: dbg topStack equals: realExecTopStack
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSkipUpToNodeDoesNotLoopWhenAimedNodeIsBeforeCurrentNode [
 
 	| sdbg aimedNode nodeBeforeSkip |
@@ -1565,7 +1573,7 @@ SindarinDebuggerTest >> testSkipUpToNodeDoesNotLoopWhenAimedNodeIsBeforeCurrentN
 	self assert: sdbg node identicalTo: nodeBeforeSkip
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipUpToNodeInEvaluatedBlock [
 
 	| dbg realExecPC realExecNode realExecTopStack oldValueOfA valueOfBAfterSkipAndStep |
@@ -1611,7 +1619,7 @@ SindarinDebuggerTest >> testSkipUpToNodeInEvaluatedBlock [
 	self assert: (dbg readVariableNamed: #b) equals: valueOfBAfterSkipAndStep 
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipUpToNodeStopsOnImplicitReturnIfAimedNodeCanStillBeExecuted [
 
 	| scdbg implicitReturnPc implicitReturnNode realExecPc realExecNode |
@@ -1653,7 +1661,7 @@ SindarinDebuggerTest >> testSkipUpToNodeStopsOnImplicitReturnIfAimedNodeCanStill
 	self assert: scdbg node identicalTo: implicitReturnNode
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipUpToNodeStopsOnReturnNodes [
 
 	| scdbg returnInBlock realExecNode |
@@ -1683,7 +1691,7 @@ SindarinDebuggerTest >> testSkipUpToNodeStopsOnReturnNodes [
 	self assert: scdbg node identicalTo: returnInBlock
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testSkipWith [
 	| a p scdbg |
 
@@ -1698,7 +1706,7 @@ SindarinDebuggerTest >> testSkipWith [
 	self assert: p equals: 5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStack [
 
 	| contextStoreBlock contextHere calleeContext scdbg |
@@ -1725,7 +1733,7 @@ SindarinDebuggerTest >> testStack [
 	self assert: scdbg stack second identicalTo: contextHere
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStatementNodeContaining [
 
 	| sdbg |
@@ -1735,7 +1743,7 @@ SindarinDebuggerTest >> testStatementNodeContaining [
 	self assert: (sdbg statementNodeContaining: sdbg node) identicalTo: sdbg methodNode statements last
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStatementNodeContainingReturnsStatementNodeThatContainsTheIdenticalSubtree [
 
 	| sdbg |
@@ -1748,7 +1756,7 @@ SindarinDebuggerTest >> testStatementNodeContainingReturnsStatementNodeThatConta
 		raise: NodeNotInASTError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStatementNodeContainingWhenNodeIsNotInAST [
 
 	| sdbg |
@@ -1760,7 +1768,7 @@ SindarinDebuggerTest >> testStatementNodeContainingWhenNodeIsNotInAST [
 		raise: NodeNotInASTError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStep [
 	| node scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -1774,7 +1782,7 @@ SindarinDebuggerTest >> testStep [
 	self assert: node selector equals: #asInteger
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStepOver [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -1785,7 +1793,7 @@ SindarinDebuggerTest >> testStepOver [
 	self assert: scdbg node selector equals: #x:y:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStepOverFinishedExecution [
 	|scdbg|
 	scdbg := SindarinDebugger debug: [ self methodWithImplicitReturn ].
@@ -1795,7 +1803,7 @@ SindarinDebuggerTest >> testStepOverFinishedExecution [
 	self should: [scdbg stepOver] raise: DebuggedExecutionIsFinished
 ]
 
-{ #category : #'tests - step return' }
+{ #category : 'tests - step return' }
 SindarinDebuggerTest >> testStepToImplicitReturn [
 	| dbg |
 
@@ -1812,7 +1820,7 @@ SindarinDebuggerTest >> testStepToImplicitReturn [
 	
 ]
 
-{ #category : #'tests - step return' }
+{ #category : 'tests - step return' }
 SindarinDebuggerTest >> testStepToMethodEntry [
 	| dbg |
 
@@ -1825,7 +1833,7 @@ SindarinDebuggerTest >> testStepToMethodEntry [
 	
 ]
 
-{ #category : #'tests - step return' }
+{ #category : 'tests - step return' }
 SindarinDebuggerTest >> testStepToNonLocalReturn [
 	| dbg |
 	
@@ -1841,7 +1849,7 @@ SindarinDebuggerTest >> testStepToNonLocalReturn [
 	
 ]
 
-{ #category : #'tests - step return' }
+{ #category : 'tests - step return' }
 SindarinDebuggerTest >> testStepToReturn [
 
 	| dbg |
@@ -1864,7 +1872,7 @@ SindarinDebuggerTest >> testStepToReturn [
 	self assert: dbg topStack equals: 2
 ]
 
-{ #category : #'tests - step return' }
+{ #category : 'tests - step return' }
 SindarinDebuggerTest >> testStepToReturnWithException [
 	| dbg |
 
@@ -1877,7 +1885,7 @@ SindarinDebuggerTest >> testStepToReturnWithException [
 	self assert: dbg method equals: (Exception >> #signal)
 ]
 
-{ #category : #'tests - step return' }
+{ #category : 'tests - step return' }
 SindarinDebuggerTest >> testStepToReturnWithHalt [
 	| dbg |
 	"First return node"
@@ -1890,7 +1898,7 @@ SindarinDebuggerTest >> testStepToReturnWithHalt [
 	self assert: dbg topStack equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testStepUntil [
 	| i scdbg |
 	i := 20.
@@ -1900,7 +1908,7 @@ SindarinDebuggerTest >> testStepUntil [
 	self assert: i equals: 12
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testSteppingAnExecutionSignalingExceptions [
 	| scdbg |
 	scdbg := SindarinDebugger
@@ -1915,7 +1923,7 @@ SindarinDebuggerTest >> testSteppingAnExecutionSignalingExceptions [
 		raise: UnhandledExceptionSignalledByADebuggedExecution
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testTemporaryNamed [
 	| dbg |
 	dbg := SindarinDebugger debug: [ self methodWithOneAssignment ].
@@ -1925,7 +1933,7 @@ SindarinDebuggerTest >> testTemporaryNamed [
 	self assert: (dbg readVariableNamed: #a) equals: 5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testTerminate [
 	| dbg |
 	dbg := SindarinDebugger debug: [ self helperMethod13 ].
@@ -1936,7 +1944,7 @@ SindarinDebuggerTest >> testTerminate [
 	self assert: dbg debugSession interruptedProcess isNil.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SindarinDebuggerTest >> testTopStack [
 	| a dbg |
 	a := 1.
@@ -1945,7 +1953,7 @@ SindarinDebuggerTest >> testTopStack [
 	self assert: dbg topStack equals: 2
 ]
 
-{ #category : #'tests - skipping' }
+{ #category : 'tests - skipping' }
 SindarinDebuggerTest >> testskipUpToNodeSkipTargetNode [
 	"The tested method takes two params: 
 		- the node up to which we want to skip execution

--- a/src/Sindarin-Tests/package.st
+++ b/src/Sindarin-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Sindarin-Tests' }
+Package { #name : 'Sindarin-Tests' }


### PR DESCRIPTION
…explanation. In summary the PR fixed a bug in #return:from: which allowed a simulation to execute an illegal return to a dead or nil context - unlike the VM which would call #cannotReturn: . The previous incorrect semantics of #return:from: was unfortunately taken advantage of if in some code and tests (see the references). In case of these two tests I'm not sure how the authors if the tests would like to fix them so leaving them as expected failures.

PS: I only pushed expected failures method;  I don't know why all symbols are being replaced with strings - this is not coming from my image... no idea why this is happening.

This is my change:
```
SindarinDebuggerTest >> expectedFailures [

	^ #( testIsExecutionFinished testStepOverFinishedExecution )
]

{ #category : 'helpers' }
```