### PR TITLE
Fix failing test in Pharo 12

### DIFF
--- a/src/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -506,8 +506,10 @@ SindarinDebuggerTest >> testIsExecutionFinished [
 	scdbg := SindarinDebugger debug: [ self methodWithTwoAssignments  ].
 	self deny: scdbg isExecutionFinished.
 
-	[ scdbg isExecutionFinished ] whileFalse: [ scdbg stepOver ].
-
+	self 
+		should: [ [ scdbg isExecutionFinished ] whileFalse: [ scdbg stepOver ]	] 
+		raise: DebuggedExecutionIsFinished.
+	
 	self assert: scdbg currentProcess isTerminated
 ]
 

--- a/src/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -1787,11 +1787,13 @@ SindarinDebuggerTest >> testStepOver [
 
 { #category : #tests }
 SindarinDebuggerTest >> testStepOverFinishedExecution [
+	"This test tries to show is that using Sindarin on a block, it should raise an exception if you continue stepping over that code in your Sindarin script while the execution of that code is already finished (nothing more to step)"
+
 	|scdbg|
 	scdbg := SindarinDebugger debug: [ self methodWithImplicitReturn ].
 	
 	"Stepping until the implicit return of #methodWithImplicitReturn"
-	scdbg stepOver: 3.		
+	scdbg stepOver: 2.		
 	self should: [scdbg stepOver] raise: DebuggedExecutionIsFinished
 ]
 


### PR DESCRIPTION

This PR propses to fix a failing test in Pharo 12, thanks to @StevenCostiou.
This started to fail since the logic of the simulation changed somewhere (meaning less or more bytecodes executed, or less or more contexts on the stack).

